### PR TITLE
Recognize .dt.date() in temporal predicate pushdown

### DIFF
--- a/polars_io_tools/io_sources/base.py
+++ b/polars_io_tools/io_sources/base.py
@@ -15,6 +15,7 @@ from .enum import (
     FunctionType,
     GenericFunctionType,
     OperatorType,
+    TemporalFunctionType,
     TimeUnit,
     get_function_enum,
 )
@@ -1101,6 +1102,10 @@ def extract_column_name(node: BaseExprNode) -> Optional[str]:
             return col_names[0]
         elif isinstance(cur, (AliasNode, CastNode)):
             cur = cur.input
+        elif isinstance(cur, FunctionNode) and cur.function_type == TemporalFunctionType.DATE and len(cur.inputs) == 1:
+            # ``col.dt.date()`` floors a Datetime to day granularity: order- and domain-preserving, hence equivalent
+            # to ``col.cast(pl.Date)`` (unwrapped above). Treat it identically so it resolves wherever a cast would.
+            cur = cur.inputs[0]
         else:
             return None
 

--- a/polars_io_tools/tests/io_sources/test_base.py
+++ b/polars_io_tools/tests/io_sources/test_base.py
@@ -79,6 +79,13 @@ def test_extract_column_name():
     expr = pl.col("b").cast(pl.Int64).alias("first").alias("second")
     assert "b" == extract_column_name(get_parsed_expr(expr))
 
+    # .dt.date() floors a Datetime column to day granularity (order-preserving, like cast(pl.Date)) and should
+    # resolve to the underlying column so temporal predicates push down.
+    expr = pl.col("ts").dt.date()
+    assert "ts" == extract_column_name(get_parsed_expr(expr))
+    expr = pl.col("ts").dt.date().alias("d")
+    assert "ts" == extract_column_name(get_parsed_expr(expr))
+
 
 def test_parse_simple_column():
     """Test parsing a simple column reference."""

--- a/polars_io_tools/tests/io_sources/test_multi_source.py
+++ b/polars_io_tools/tests/io_sources/test_multi_source.py
@@ -233,6 +233,29 @@ class TestMultiSourceBasic:
         # With maintain_order="left", row order should be preserved
         assert_frame_equal(result, expected)
 
+    def test_dt_date_filter_prunes_datetime_source(self):
+        """A ``.dt.date()`` window on a Datetime source prunes upstream (no full scan) and stays correct.
+
+        ``.dt.date()`` floors to day granularity (order-preserving, like ``cast(pl.Date)``), so the temporal range
+        must still be extracted and pushed down rather than collapsing to the universe interval.
+        """
+        ts = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(90)]
+        df = pl.DataFrame({"ts": ts, "val": list(range(90))})
+        tracker = PredicateTracker(df)
+
+        lf = multi_source(
+            sources={"data": (tracker.lazy_frame, {"ts": FilterSpec()})},
+            combine=lambda s: s["data"],
+        )
+
+        start, end = date(2024, 1, 1), date(2024, 1, 31)
+        result = lf.filter((pl.col("ts").dt.date() >= start) & (pl.col("ts").dt.date() <= end)).collect()
+
+        # Range was extracted, so the source received a constraining predicate (not a silent full scan).
+        assert tracker.last_predicate is not None
+        assert result.height == 31
+        assert result["ts"].max() == datetime(2024, 1, 31)
+
     def test_simple_equality_filter(self):
         """Equality filter propagates correctly."""
         left = pl.LazyFrame({"id": ["A", "B", "C"], "val": [1, 2, 3]})


### PR DESCRIPTION
## Summary

`multi_source` and the lazy IO readers prune which partitions / date ranges to fetch by extracting a temporal interval from the query predicate (`convert_expr_to_datetime_range` → `extract_column_name`). That extraction only resolved a column when it appeared as a **bare column, alias, or cast**. If the column was wrapped in a function — notably `pl.col("Date").dt.date()` — the extractor returned `None`, the range collapsed to the universe interval `(-inf, +inf)`, and callers treated that as *"no constraint"* and **scanned the entire source / full date range**.

The query result stayed correct (the predicate is re-applied downstream), but a filter that *looks* like it prunes silently triggered a full scan — in practice turning a one-month read into a full multi-year scan on every worker of a distributed job.

```python
# pushed down today:
pl.col("Date").is_between(start, end)
pl.col("Date").cast(pl.Date).is_between(start, end)

# silently full-scanned today, fixed by this PR:
(pl.col("Date").dt.date() >= start) & (pl.col("Date").dt.date() <= end)
```

## The fix

`extract_column_name` now unwraps a `DATE` temporal function node (single input) the same way it already unwraps `CastNode`. `.dt.date()` floors a `Datetime` column to day granularity — it is order- and domain-preserving and **semantically equivalent to `cast(pl.Date)`**, which is already supported. After the change, `.dt.date()` is treated **identically to `cast(pl.Date)`** across every consumer of the helper (range extraction, DNF / set / translated predicate visitors).

Native polars already pushes `.dt.date() >= x` down to the scan as a SELECTION, so this aligns us with upstream polars behaviour rather than diverging from it.

## Scope (deliberately narrow)

Only `TemporalFunctionType.DATE` is recognized:

- `.dt.year()` / `.dt.month()` — monotonic but **not domain-preserving** (the literal is an integer year/month, not a column-domain value), so substituting it as a column bound is meaningless.
- `.dt.truncate(...)` — domain-preserving but floors at a granularity **wider than the existing day-widening covers**, which could yield an under-broad upper bound.

Both continue to return the universe interval (no pruning; the predicate is still re-applied in memory, so results stay correct).

## Correctness note

This change makes `.dt.date()` **byte-for-byte equivalent to `cast(pl.Date)`** in every code path (verified for range extraction in both `preserve_dates` modes, and for `TranslatedPredicateVisitor` with mapped and unmapped columns). The safe claim is therefore *equivalence to the already-supported `cast(pl.Date)` wrapper*, **not** "sound for all callers."

There is a separate, **pre-existing** latent concern shared by the `cast(pl.Date)` path: for callers that consume the interval as the literal fetch window with `preserve_dates=False` (e.g. `lazy_datadog_reader`, `lazy_ray`), a date-typed upper bound like `... <= date(d)` resolves to `d 00:00:00` rather than the full day, which can under-cover intraday rows on the boundary day. `multi_source` handles this correctly via `preserve_dates=True` + full-day widening. This affects `cast(pl.Date)` today identically and is **out of scope** here — it should be addressed separately for both wrappers if we want those callers to be sound for date-floor predicates.

## Tests

- `test_extract_column_name` — `.dt.date()` (and aliased) now resolve to the underlying column.
- `test_dt_date_filter_prunes_datetime_source` — end-to-end: a `.dt.date()` window on a `Datetime` source prunes upstream (a constraining predicate reaches the source) and returns the correct rows.

Full `io_sources` suite passes (1189 passed, 2 skipped, 6 xfailed); ruff check + format clean.

## Review

An independent review (separate model) flagged the shared-helper blast radius; after verifying the exact `cast(pl.Date)` equivalence above, it gave a go under the equivalence contract and confirmed there is no predicate shape where `.dt.date()` is strictly worse than `cast(pl.Date)`.