### PR TITLE
cache_parquet: raise instead of silently dropping rows above the open-sink cap

### DIFF
--- a/polars_io_tools/io_sources/lazy_cache_parquet.py
+++ b/polars_io_tools/io_sources/lazy_cache_parquet.py
@@ -2,6 +2,7 @@ import datetime
 import functools
 import logging
 import operator
+import os
 import time
 from dataclasses import dataclass
 from datetime import date, timedelta
@@ -72,8 +73,21 @@ def _prepare_lf_for_sink_from_io_source(lf: pl.LazyFrame) -> pl.LazyFrame:
 
 # Constants
 
-_MAX_PARTITIONED_SINK_PARTITIONS = 64
+# Polars' default cap on how many partition sinks may be open at once (the
+# POLARS_MAX_OPEN_SINKS default). Writes are checked against this cap.
+_DEFAULT_MAX_OPEN_SINKS = 128
 _MAX_ENUMERATED_SCAN_PATHS = 64
+
+
+def _max_open_sinks() -> int:
+    """Return the open-sink cap polars will enforce (POLARS_MAX_OPEN_SINKS, or the default)."""
+    raw = os.environ.get("POLARS_MAX_OPEN_SINKS")
+    if raw is None:
+        return _DEFAULT_MAX_OPEN_SINKS
+    try:
+        return int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_OPEN_SINKS
 
 
 def _dataframe_write_parquet_kwargs(
@@ -94,42 +108,6 @@ def _dataframe_write_parquet_kwargs(
     if credential_provider:
         parquet_kwargs["credential_provider"] = credential_provider
     return parquet_kwargs
-
-
-def _write_partitioned_lf_sequentially(
-    lf: pl.LazyFrame,
-    *,
-    key_exprs: List[pl.Expr],
-    key_names: List[str],
-    time_unit_dir: str,
-    metadata: dict[str, str],
-    storage_options: dict,
-    credential_provider: Optional[pl.CredentialProviderAWS],
-    write_kwargs: dict,
-) -> set[str]:
-    df = lf.with_columns(key_exprs).collect()
-    if df.is_empty():
-        return set()
-
-    parquet_kwargs = _dataframe_write_parquet_kwargs(
-        write_kwargs=write_kwargs,
-        metadata=metadata,
-        storage_options=storage_options,
-        credential_provider=credential_provider,
-    )
-
-    written_keys: set[str] = set()
-    groups = df.partition_by(key_names, maintain_order=True, include_key=True, as_dict=True)
-    for key_tuple, group in groups.items():
-        key_values = [unquote(str(v)) for v in key_tuple]
-        key_path = "/".join(key_values)
-        written_keys.add(key_path)
-
-        path_parts = key_values[:-1]
-        path_parts.append(f"{key_values[-1]}.parquet")
-        group.drop(key_names).write_parquet(f"{time_unit_dir}/{'/'.join(path_parts)}", **parquet_kwargs)
-
-    return written_keys
 
 
 def _write_empty_parquet_files_sequentially(
@@ -1565,6 +1543,11 @@ def cache_parquet(
           instead of a glob, reducing metadata scans. Falls back to glob when enumeration isn't possible.
         - Partition completeness assumption: if a partition has any data in cache, it's assumed complete
           for the purpose of unbounded queries.
+        - Open-sink cap: a single write opens one streaming sink per partition. Polars caps the number
+          of simultaneously open sinks (``POLARS_MAX_OPEN_SINKS``, default 128); exceeding it would
+          silently drop rows, so ``cache_parquet`` raises instead. To write more partitions in one call,
+          set ``POLARS_MAX_OPEN_SINKS`` above the partition count *before the process starts*, or reduce
+          the partition count per call (e.g. a coarser ``time_unit`` or chunked date ranges).
     """
     if cache_mode == CacheMode.IGNORE:
         return self_or_fn() if callable(self_or_fn) else self_or_fn
@@ -1740,19 +1723,6 @@ def cache_parquet(
                 if bounding_pred is not None:
                     lf_to_write = lf_to_write.filter(bounding_pred)
 
-            key_parts = [pl.col("keys").struct.field(f"__piot_key_{c}__").cast(pl.Utf8) for c in _extra_cols]
-            if DATE_KEY_ALIAS is not None:
-                key_parts.append(pl.col("keys").struct.field(DATE_KEY_ALIAS).cast(pl.Utf8))
-
-            key_names = [f"__piot_key_{c}__" for c in _extra_cols]
-            if DATE_KEY_ALIAS is not None:
-                key_names.append(DATE_KEY_ALIAS)
-
-            # Handle single partition case - add the dummy key we created earlier
-            if not key_parts and not _extra_cols and date_column is None:
-                key_parts.append(pl.col("keys").struct.field("__piot_key_single__").cast(pl.Utf8))
-                key_names.append("__piot_key_single__")
-
             # Track written partition keys via file_path callback
             tracked_keys: set[str] = set()
 
@@ -1760,7 +1730,20 @@ def cache_parquet(
                 """Generate file path for each partition and track written keys."""
                 # Handle API differences between PartitionBy (new) and PartitionByKey (old)
                 if hasattr(ctx, "partition_keys"):
-                    # PartitionBy: ctx.partition_keys is a single-row DataFrame
+                    # index_in_partition > 0 means polars reopened this sink after
+                    # eviction; the reopened sink would overwrite the partition's
+                    # earlier file, so fail here instead of losing rows. Raise (not
+                    # assert) so it survives `python -O`.
+                    if ctx.index_in_partition != 0:
+                        raise RuntimeError(
+                            "cache_parquet: polars reopened a partition sink "
+                            f"(index_in_partition={ctx.index_in_partition}) for key "
+                            f"{ctx.partition_keys.row(0)!r}. The open-sink cap "
+                            f"({_max_open_sinks()}) was exceeded and rows would be "
+                            "silently dropped. Set POLARS_MAX_OPEN_SINKS above the "
+                            "partition count before the process starts, or write fewer "
+                            "partitions per call."
+                        )
                     key_values = [unquote(str(v)) for v in ctx.partition_keys.row(0)]
                 else:
                     # PartitionByKey: ctx.keys is a list of key objects with .str_value
@@ -1783,6 +1766,10 @@ def cache_parquet(
                     key=key_exprs,
                     file_path_provider=_file_path_callback,
                     include_key=False,
+                    # Disable size-based splitting so each partition is one file
+                    # (index_in_partition stays 0); otherwise a large partition could be
+                    # split, breaking the one-file-per-partition layout the reader expects.
+                    approximate_bytes_per_file=None,
                 )
             else:
                 partition_obj = pl.PartitionByKey(
@@ -1798,36 +1785,34 @@ def cache_parquet(
                 extra_cols=_extra_cols,
                 user_metadata=write_kwargs.get("metadata"),
             )
-            if len(partitions_to_write_df) > _MAX_PARTITIONED_SINK_PARTITIONS:
-                log.debug(
-                    "Writing partitions sequentially because %d partition(s) exceed limit %d",
-                    len(partitions_to_write_df),
-                    _MAX_PARTITIONED_SINK_PARTITIONS,
+            # Above the open-sink cap, polars evicts and reopens partition sinks, and the
+            # custom file_path_provider's reopened sink overwrites the partition's earlier
+            # file, silently dropping rows. Reject here when the partition count is known
+            # up front; the callback's index_in_partition check is the runtime backstop for
+            # cases (e.g. unbounded queries) where it isn't.
+            n_partitions = len(partitions_to_write_df)
+            max_open_sinks = _max_open_sinks()
+            if n_partitions > max_open_sinks:
+                raise ValueError(
+                    f"cache_parquet would write {n_partitions} partitions in a single "
+                    f"streaming sink, exceeding the polars open-sink cap of "
+                    f"{max_open_sinks}. Exceeding the cap silently drops rows. Set the "
+                    "POLARS_MAX_OPEN_SINKS environment variable above the partition "
+                    "count BEFORE the process starts, or write fewer partitions per "
+                    "call (e.g. a coarser time_unit or chunked date ranges)."
                 )
-                tracked_keys.update(
-                    _write_partitioned_lf_sequentially(
-                        lf_to_write,
-                        key_exprs=key_exprs,
-                        key_names=key_names,
-                        time_unit_dir=time_unit_dir,
-                        metadata=cache_metadata,
-                        storage_options=polars_opts,
-                        credential_provider=credential_provider,
-                        write_kwargs=write_kwargs,
-                    )
-                )
-            else:
-                sink_write_kwargs = dict(write_kwargs)
-                sink_write_kwargs.pop("metadata", None)
-                _prepare_lf_for_sink_from_io_source(lf_to_write).sink_parquet(  # type: ignore[call-overload]
-                    partition_obj,
-                    maintain_order=True,
-                    mkdir=True,
-                    metadata=cache_metadata,
-                    storage_options=polars_opts,
-                    **({"credential_provider": credential_provider} if credential_provider else {}),
-                    **sink_write_kwargs,
-                )
+
+            sink_write_kwargs = dict(write_kwargs)
+            sink_write_kwargs.pop("metadata", None)
+            _prepare_lf_for_sink_from_io_source(lf_to_write).sink_parquet(  # type: ignore[call-overload]
+                partition_obj,
+                maintain_order=True,
+                mkdir=True,
+                metadata=cache_metadata,
+                storage_options=polars_opts,
+                **({"credential_provider": credential_provider} if credential_provider else {}),
+                **sink_write_kwargs,
+            )
 
             # Update written_parts from tracked keys
             written_parts.update(tracked_keys)

--- a/polars_io_tools/tests/io_sources/test_lazy_cache_parquet.py
+++ b/polars_io_tools/tests/io_sources/test_lazy_cache_parquet.py
@@ -1183,11 +1183,14 @@ def test_push_and_parse_exclusions_to_custom_io_source(tmp_path):
     )  # we have data for "NA" cached, so shouldnt query
 
 
-def test_large_partition_query(tmp_path):
+def test_large_partition_query(tmp_path, monkeypatch):
     """
     Test that we correctly write empty partitions for daily partitions when
     extra partition columns are specified, and there is a gap.
     """
+    # More partitions than the default open-sink cap (128); raise it so the streaming
+    # sink can keep every partition open at once.
+    monkeypatch.setenv("POLARS_MAX_OPEN_SINKS", "8192")
     df = pl.LazyFrame(
         {
             "date": pl.date_range(datetime.date(2020, 1, 1), datetime.date(2026, 1, 1), eager=True),
@@ -1228,10 +1231,15 @@ def test_large_partition_query(tmp_path):
     assert missing_expected.is_empty(), "missing expected rows in the result"
 
 
-def test_huge_partition_query(tmp_path, caplog):
+def test_huge_partition_query(tmp_path, caplog, monkeypatch):
     """
     Test a large partition query that spans multiple years. We have partial data in the cache, and if we submitted each requested partition as a combination of OR's, we would end up with a very large query that could segfault.
     """
+    # This query writes far more partitions than the default open-sink cap (128). Raise
+    # the cap so the streaming partitioned sink keeps every partition open at once; the
+    # cache adapter refuses to exceed whatever cap is in effect rather than silently
+    # dropping rows.
+    monkeypatch.setenv("POLARS_MAX_OPEN_SINKS", "8192")
     df = pl.LazyFrame(
         {
             "date": pl.date_range(datetime.date(2020, 1, 1), datetime.date(2026, 1, 1), eager=True),
@@ -1280,9 +1288,21 @@ def test_huge_partition_query(tmp_path, caplog):
     assert_frame_equal(res2.sort("date", "region"), expected.sort("date", "region"))
     # Huge bounded queries avoid very large explicit path lists on Windows.
     logs = caplog.text
-    assert "Writing partitions sequentially" in logs
-    assert "exceeding limit" in logs
     assert "Cache scan uses glob" in logs
+
+
+def test_partition_count_exceeds_open_sinks_raises(tmp_path, monkeypatch):
+    """Writing more partitions than the open-sink cap fails loud instead of dropping rows."""
+    monkeypatch.setenv("POLARS_MAX_OPEN_SINKS", "4")
+    df = pl.LazyFrame(
+        {
+            "date": pl.date_range(datetime.date(2020, 1, 1), datetime.date(2020, 1, 10), eager=True),
+            "value": range(10),
+        }
+    )
+    pred = pl.col.date.is_between(datetime.date(2020, 1, 1), datetime.date(2020, 1, 10))
+    with pytest.raises(Exception, match="open-sink cap"):
+        df.piot.cache_parquet(cache_path=tmp_path, date_column="date", time_unit="daily").filter(pred).collect()
 
 
 def test_get_fs_path_directory_info_strips_trailing_slash_s3():


### PR DESCRIPTION
## Problem

`cache_parquet` writes one streaming sink per partition, using a custom `file_path_provider` to name the files. Polars limits how many sinks can be open at once (`POLARS_MAX_OPEN_SINKS`, default 128). When a write has more partitions than that, polars closes and reopens sinks to stay under the limit. With a custom provider, the reopened sink writes to the same filename and overwrites what was already there, so rows are lost with no error or warning.

The existing code avoided the bug by collecting the whole frame into memory and writing each partition one at a time whenever there were more than 64 partitions. That works, but it gives up streaming exactly when the data is largest.

## Change

Keep streaming, and refuse to write more partitions than the cap allows:

- If the partition count is known before the write, raise a `ValueError` explaining how to fix it (raise the env var or write fewer partitions per call).
- For queries where the count isn't known up front, the `file_path_provider` now raises if `index_in_partition != 0`, which is the signal that polars reopened a sink. This catches the unsafe case at runtime instead of losing data.
- Pass `approximate_bytes_per_file=None` so polars doesn't split a single large partition into multiple files, which would also break the one-file-per-partition layout the cache reader expects.
- Remove the now-unused in-memory write path (and some dead `key_parts`/`key_names` code it relied on).

The on-disk layout is unchanged, so existing caches and all the read code keep working. The only behaviour change is that a write that would have silently dropped rows now errors instead.

To write more partitions than the cap in a single call, set `POLARS_MAX_OPEN_SINKS` above the partition count before the process starts, or split the write into smaller chunks (a coarser `time_unit`, or narrower date ranges).

## Tests

- New `test_partition_count_exceeds_open_sinks_raises`: cap of 4, 10 partitions, expects a raise.
- `test_large_partition_query` and `test_huge_partition_query` now set `POLARS_MAX_OPEN_SINKS` high (the supported way to write that many partitions) and drop the old assertions about the in-memory path.
- io_sources suite: 1190 passed, 2 skipped, 6 xfailed. Ruff clean.

## Setting the cap

`cache_parquet` only reads `POLARS_MAX_OPEN_SINKS`; it never sets it. As the polars docs note, the variable must be set before polars starts to take effect, so writing more partitions than the default cap is opt-in: set it in the environment before launching the process.