### PR TITLE
Use tuples consistently for __all__

### DIFF
--- a/polars_io_tools/io_sources/base.py
+++ b/polars_io_tools/io_sources/base.py
@@ -36,10 +36,10 @@ T = TypeVar("T")
 FAILED_LITERAL_RESULT = object()
 
 # Define public exports
-__all__ = [
+__all__ = (
     "convert_datetime_to_polars",
     "extract_column_name",
-]
+)
 
 
 if version.parse(pl.__version__) < version.parse("1.28.0"):

--- a/polars_io_tools/io_sources/delta_io.py
+++ b/polars_io_tools/io_sources/delta_io.py
@@ -23,10 +23,10 @@ if TYPE_CHECKING:
 # The mapping is stored as base64-encoded JSON between [tag:begin] and [tag:end] markers.
 _MAPPING_BLOCK_TAG = "cpl.mapping"
 
-__all__ = [
+__all__ = (
     "scan_delta",
     "sink_delta",
-]
+)
 
 log = logging.getLogger(__name__)
 

--- a/polars_io_tools/io_sources/enum.py
+++ b/polars_io_tools/io_sources/enum.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import polars as pl
 
-__all__ = [
+__all__ = (
     "ArrayFunctionType",
     "BinaryFunctionType",
     "BitwiseFunctionType",
@@ -19,7 +19,7 @@ __all__ = [
     "TimeUnit",
     "TrigonometricFunctionType",
     "get_function_enum",
-]
+)
 
 
 class Expr(str, Enum):

--- a/polars_io_tools/io_sources/lazy_cache.py
+++ b/polars_io_tools/io_sources/lazy_cache.py
@@ -12,7 +12,7 @@ from .util import register_io_source_with_is_pure
 log = logging.getLogger(__name__)
 
 
-__all__ = ["cache"]
+__all__ = ("cache",)
 
 
 _PartitionKey = tuple[tuple[str, Any], ...]

--- a/polars_io_tools/io_sources/lazy_cache_parquet.py
+++ b/polars_io_tools/io_sources/lazy_cache_parquet.py
@@ -51,7 +51,7 @@ class ReadPlan:
 
 log = logging.getLogger(__name__)
 
-__all__ = ["CacheMode", "cache_parquet"]
+__all__ = ("CacheMode", "cache_parquet")
 
 
 def _path_as_file_uri(path: Path | PureWindowsPath) -> str:

--- a/polars_io_tools/io_sources/lazy_clickhouse_reader.py
+++ b/polars_io_tools/io_sources/lazy_clickhouse_reader.py
@@ -11,7 +11,7 @@ from .sql_utils import (
 )
 from .util import register_io_source_with_is_pure
 
-__all__ = ["scan_clickhouse"]
+__all__ = ("scan_clickhouse",)
 
 
 # Configure logging

--- a/polars_io_tools/io_sources/lazy_clickhouse_writer.py
+++ b/polars_io_tools/io_sources/lazy_clickhouse_writer.py
@@ -7,7 +7,7 @@ import requests
 
 from .._compat import POLARS_HAS_COLLECT_BATCHES
 
-__all__ = ["sink_clickhouse"]
+__all__ = ("sink_clickhouse",)
 
 
 # Configure logging

--- a/polars_io_tools/io_sources/lazy_datadog_reader.py
+++ b/polars_io_tools/io_sources/lazy_datadog_reader.py
@@ -8,7 +8,7 @@ import portion
 from .range_visitor import convert_expr_to_datetime_range
 from .util import _convert_interval_to_slices, register_io_source_with_is_pure
 
-__all__ = ["metric_query", "scan_datadog"]
+__all__ = ("metric_query", "scan_datadog")
 
 
 def metric_query(query: str, start: int, end: int, api_key: str, app_key: str, interval: int | None = None) -> dict:

--- a/polars_io_tools/io_sources/lazy_narwhals_reader.py
+++ b/polars_io_tools/io_sources/lazy_narwhals_reader.py
@@ -15,7 +15,7 @@ from .base import AliasNode, BaseExprNode, BinaryExprNode, CastNode, ColumnNode,
 from .enum import BooleanFunctionType, OperatorType
 from .util import collect_lf_in_io_source, register_io_source_with_is_pure
 
-__all__ = ["from_narwhals"]
+__all__ = ("from_narwhals",)
 
 log = logging.getLogger(__name__)
 

--- a/polars_io_tools/io_sources/lazy_ray.py
+++ b/polars_io_tools/io_sources/lazy_ray.py
@@ -22,7 +22,7 @@ from .util import register_io_source_with_is_pure
 # As we did in the `lazy_parquet_cache` module, we expose the function to users, in case
 # they want to use it directly or though Polars' `.pipe()` syntax; however, the canonical
 # useage is to call the function as a method on the `LazyFrame`'s `piot` namespace.
-__all__ = ["execute_on_ray"]
+__all__ = ("execute_on_ray",)
 
 
 def _partition_specs(

--- a/polars_io_tools/io_sources/lazy_sql_reader.py
+++ b/polars_io_tools/io_sources/lazy_sql_reader.py
@@ -13,7 +13,7 @@ from .sql_utils import (
 )
 from .util import register_io_source_with_is_pure
 
-__all__ = ["scan_db"]
+__all__ = ("scan_db",)
 
 
 # Configure logging

--- a/polars_io_tools/io_sources/range_visitor.py
+++ b/polars_io_tools/io_sources/range_visitor.py
@@ -19,10 +19,10 @@ from .enum import (
 log = logging.getLogger(__name__)
 
 # Export only what's needed publicly
-__all__ = [
+__all__ = (
     "convert_expr_to_datetime_range",
     "convert_expr_to_range",
-]
+)
 
 # Type definition for validated datetime
 ValidatedDatetime = Annotated[

--- a/polars_io_tools/io_sources/sql_utils.py
+++ b/polars_io_tools/io_sources/sql_utils.py
@@ -10,13 +10,13 @@ from .base import AliasNode, BinaryExprNode, CastNode, ColumnNode, ExprVisitor, 
 from .enum import ArrayFunctionType, BooleanFunctionType, ListFunctionType, OperatorType, StringFunctionType, TemporalFunctionType
 from .sql_dialects import MSSQL
 
-__all__ = [
+__all__ = (
     "SQLExpressionVisitor",
     "apply_polars_io_source_exprs",
     "convert_predicate_to_sql",
     "create_sqlglot_literal",
     "fix_three_part_identifiers",
-]
+)
 
 
 # Configure logging

--- a/polars_io_tools/io_sources/translated_source.py
+++ b/polars_io_tools/io_sources/translated_source.py
@@ -27,7 +27,7 @@ from .base import get_parsed_expr
 
 log = logging.getLogger(__name__)
 
-__all__ = ["TranslatedPredicateVisitor", "translate_polars_predicate"]
+__all__ = ("TranslatedPredicateVisitor", "translate_polars_predicate")
 
 
 def _to_target_expr(col: pl.Expr, m: pl.DataType | None) -> pl.Expr:


### PR DESCRIPTION
The package was a ~50/50 split between tuple and list `__all__` declarations. Standardize on **tuples** for consistency with the sibling `ccflow` project and the org house style, and because an immutable tuple better signals a fixed export list.

Mechanical change to the 14 list-style modules (`[]` → `()`, with the single-element trailing comma handled). No behavior change — public API surface is identical; `ruff check`/`format` and the full test suite pass.