### PR TITLE
Update stale multi_source references in pushdown wrapper comments

### DIFF
--- a/polars_io_tools/io_sources/pushdown_pivot.py
+++ b/polars_io_tools/io_sources/pushdown_pivot.py
@@ -114,7 +114,7 @@ def pushdown_pivot(
     # Defer all `collect_schema()` walks (the source schema, the full pivot output schema, and the per-`on`-value pivot
     # schemas used for the output→on-value mapping) until Polars actually needs them — typically when it asks for the
     # registered schema at collect time. This avoids forcing schema resolution on the input LazyFrame eagerly when the
-    # wrapper is constructed (the convention documented on `register_io_source_with_is_pure` and used by `multi_source`).
+    # wrapper is constructed (the convention documented on `register_io_source_with_is_pure` and used by `pushdown_combine`).
     _resolved: dict[str, Any] = {}
 
     def _resolve() -> dict[str, Any]:

--- a/polars_io_tools/io_sources/pushdown_unpivot.py
+++ b/polars_io_tools/io_sources/pushdown_unpivot.py
@@ -68,7 +68,7 @@ def pushdown_unpivot(
     # Defer all `collect_schema()` walks (the source schema, the resolved on-columns list, and the declared unpivot output
     # schema) until Polars actually needs them — typically when it asks for the registered schema at collect time. This
     # avoids forcing schema resolution on the input LazyFrame eagerly when the wrapper is constructed (the convention
-    # documented on `register_io_source_with_is_pure` and used by `multi_source`).
+    # documented on `register_io_source_with_is_pure` and used by `pushdown_combine`).
     _resolved: dict[str, Any] = {}
 
     def _resolve() -> dict[str, Any]:


### PR DESCRIPTION
Follow-up to the `multi_source` → `pushdown_combine` rename (#16).

The `pushdown_pivot` / `pushdown_unpivot` wrappers (added in #12, in flight during the rename) still referenced the old `multi_source` name in explanatory comments. Comment-only update to point at `pushdown_combine`. No behavior change.

After this, `grep -r multi_source` is empty across the repo.