### PR TITLE
Make S3 endpoint hostname resolution opt-in

### DIFF
--- a/polars_io_tools/io_sources/util.py
+++ b/polars_io_tools/io_sources/util.py
@@ -69,6 +69,17 @@ class StorageOptions(NamedTuple):
     credential_provider: pl.CredentialProviderAWS | None
 
 
+# S3 endpoint URLs whose hostname should be resolved to an IP address before use.
+#
+# Empty by default. Resolving a hostname to an IP is only appropriate for endpoints
+# where it is known to be safe -- typically plain-HTTP on-prem object stores where
+# resolving up front avoids overloading DNS when many workers connect at once. It is
+# NOT safe to do unconditionally: replacing the hostname of an HTTPS endpoint with an
+# IP breaks TLS certificate validation. Deployments that want this behaviour opt in by
+# adding the relevant endpoint URLs to this set, e.g. ``ENDPOINTS_TO_RESOLVE.add(url)``.
+ENDPOINTS_TO_RESOLVE: set[str] = set()
+
+
 @functools.lru_cache(maxsize=16)
 def _resolve_endpoint_hostname(endpoint: str) -> str:
     """Resolve the hostname in an endpoint URL to an IP address.
@@ -164,7 +175,9 @@ def _storage_options_for(cache_uri: str, aws_profile: str | None = None) -> Stor
         cred_opts = credential_provider._storage_update_options()
         endpoint = cred_opts.get("endpoint_url")
 
-    if endpoint:
+    # Resolve the endpoint hostname to an IP address only for endpoints that have
+    # explicitly opted in via ``ENDPOINTS_TO_RESOLVE`` (see its definition above).
+    if endpoint in ENDPOINTS_TO_RESOLVE:
         endpoint = _resolve_endpoint_hostname(endpoint)
 
     # Set endpoint in both option dicts with appropriate keys

--- a/polars_io_tools/tests/io_sources/test_util.py
+++ b/polars_io_tools/tests/io_sources/test_util.py
@@ -753,6 +753,56 @@ class TestWithColumnsTopo:
         assert_frame_equal(df.select(expected.columns), expected)
 
 
+class TestEndpointResolutionOptIn:
+    """`_storage_options_for` resolves an endpoint hostname only when it opts in."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_registry(self):
+        from polars_io_tools.io_sources import util as _util
+
+        snapshot = set(_util.ENDPOINTS_TO_RESOLVE)
+        _resolve_endpoint_hostname.cache_clear()
+        yield
+        _util.ENDPOINTS_TO_RESOLVE.clear()
+        _util.ENDPOINTS_TO_RESOLVE.update(snapshot)
+        _resolve_endpoint_hostname.cache_clear()
+
+    @staticmethod
+    def _patch_no_cred_session(monkeypatch):
+        class FakeSession:
+            def __init__(self, profile_name=None):
+                self.region_name = None
+
+            def get_credentials(self):
+                return None
+
+        monkeypatch.setattr("boto3.Session", FakeSession)
+
+    def test_unregistered_endpoint_is_left_as_hostname(self, monkeypatch):
+        self._patch_no_cred_session(monkeypatch)
+        monkeypatch.setattr("socket.gethostbyname", lambda hostname: "10.9.9.9")
+
+        uri = "s3://bucket/path?endpoint_override=http://onprem-store:9020"
+        opts = _storage_options_for(uri)
+
+        # Default registry is empty, so the endpoint is passed through unchanged.
+        assert opts.polars["endpoint_url"] == "http://onprem-store:9020"
+        assert opts.pyarrow["endpoint_override"] == "http://onprem-store:9020"
+
+    def test_registered_endpoint_is_resolved_to_ip(self, monkeypatch):
+        from polars_io_tools.io_sources import util as _util
+
+        self._patch_no_cred_session(monkeypatch)
+        monkeypatch.setattr("socket.gethostbyname", lambda hostname: "10.9.9.9")
+        _util.ENDPOINTS_TO_RESOLVE.add("http://onprem-store:9020")
+
+        uri = "s3://bucket/path?endpoint_override=http://onprem-store:9020"
+        opts = _storage_options_for(uri)
+
+        assert opts.polars["endpoint_url"] == "http://10.9.9.9:9020"
+        assert opts.pyarrow["endpoint_override"] == "http://10.9.9.9:9020"
+
+
 class TestStorageOptionsFor:
     """Tests for `_storage_options_for` with thorough boto3/session mocking."""
 
@@ -1192,7 +1242,13 @@ class TestResolveEndpointHostname:
         monkeypatch.setattr("socket.gethostbyname", failing_gethostbyname)
         monkeypatch.setenv("AWS_ENDPOINT_URL", "http://grid:9020")
 
-        opts = _storage_options_for("s3://bucket/path")
+        from polars_io_tools.io_sources import util as _util
+
+        _util.ENDPOINTS_TO_RESOLVE.add("http://grid:9020")
+        try:
+            opts = _storage_options_for("s3://bucket/path")
+        finally:
+            _util.ENDPOINTS_TO_RESOLVE.discard("http://grid:9020")
 
         # Endpoint should be kept as original due to resolution failure
         assert opts.pyarrow["endpoint_override"] == "http://grid:9020"


### PR DESCRIPTION
`_storage_options_for` resolved the endpoint hostname to an IP for **every** S3 endpoint. That is only safe for plain-HTTP on-prem object stores (where resolving up front avoids overloading DNS when many workers connect at once) — for an **HTTPS** endpoint it replaces the hostname with an IP and breaks TLS certificate validation.

This gates the resolution on a new, empty-by-default `ENDPOINTS_TO_RESOLVE` set. Default behaviour is now pass-through (no resolution); deployments that want it opt in:

```python
from polars_io_tools.io_sources import util
util.ENDPOINTS_TO_RESOLVE.add("http://onprem-store:9020")
```

The existing tests used non-resolvable hostnames (so the old unconditional call was already a no-op via `gaierror`); adds tests for both the opt-in (resolved) and default (pass-through) paths. Full `test_util`, `test_delta_io`, `test_lazy_cache_parquet` pass; ruff clean.