### PR TITLE
feat(cache): add cache_memory, an in-memory builder-driven cache

### DIFF
--- a/docs/wiki/API-Reference.md
+++ b/docs/wiki/API-Reference.md
@@ -42,6 +42,26 @@ only the partitions their predicate needs; missing partitions are fetched upstre
 written back. `time_unit` is `"daily"`, `"monthly"`, or `"yearly"`. Returns a LazyFrame
 reading from the cache.
 
+### `cache_memory`
+
+```python
+lf.piot.cache_memory(*, schema)
+```
+
+Collect the LazyFrame once into an in-memory buffer and replay it on every subsequent
+reference or collect, so a frame referenced from several branches executes upstream once
+rather than once per reference. Unlike `cache`, the key is not derived by serializing the
+plan — the buffer lives in the returned frame's own closure — so it also works with
+`register_io_source` plugins that close over non-serializable state (a connection, a lock,
+an open iterator). `schema` is the declared output schema, or a zero-argument callable
+returning it; a callable lets `collect_schema()` resolve without materializing the buffer.
+The collected frame is reconciled against `schema` once (a missing declared column or dtype
+mismatch raises; extra columns are dropped), and predicates and projections are applied to
+the buffer after materialization. The build runs at most once: a failure is recorded and
+re-raised on later collects, and the buffer is released when the returned frame is dropped.
+As a top-level function, `cache_memory(build_or_lf, *, schema)` additionally accepts a
+zero-argument builder callable, executed on first row demand, in place of a LazyFrame.
+
 ### `debug`
 
 ```python

--- a/docs/wiki/Query-Optimization.md
+++ b/docs/wiki/Query-Optimization.md
@@ -211,6 +211,29 @@ lf.filter(pl.col("date").is_between(pl.date(2024, 1, 1), pl.date(2024, 3, 31))).
 Use `cache_mode=CacheMode.REBUILD` to refresh partitions in the query scope while leaving
 others intact, and `aws_profile=` to select S3 credentials.
 
+## Cache in memory across a multi-branch evaluation
+
+Polars' common-subplan elimination does not deduplicate independent references to an
+IO-backed source, so a source read from several branches of one evaluation is re-executed
+once per reference. `cache_memory` collects it once into an in-memory buffer and replays
+that buffer on every reference, collapsing them to a single upstream execution — with no
+serialization (unlike `cache`) and no Parquet round-trip (unlike `cache_parquet`).
+
+```python
+# `source` is a scan_* frame or a register_io_source plugin, possibly non-serializable.
+cached = source.piot.cache_memory(schema=source.collect_schema())
+
+# Every branch reads the shared buffer; the source is executed once, not three times.
+a = cached.filter(pl.col("region") == "US")
+b = cached.filter(pl.col("region") == "EU")
+c = cached.group_by("sector").agg(pl.col("value").mean())
+pl.collect_all([a, b, c])
+```
+
+Pass a zero-argument builder to the top-level `cache_memory(build, schema=...)` to defer an
+expensive build until first collect, and a callable `schema` so `collect_schema()` resolves
+without running it. The buffer is reclaimed when `cached` is dropped.
+
 ## Control pushdown explicitly
 
 Two helpers give you manual control when the optimizer's defaults are not what you want:

--- a/polars_io_tools/io_sources/__init__.py
+++ b/polars_io_tools/io_sources/__init__.py
@@ -9,6 +9,7 @@ from .concat_named import *
 from .delta_io import *
 from .join import *
 from .lazy_cache import cache, cache as _lazy_cache
+from .lazy_cache_memory import *
 from .lazy_cache_parquet import *
 from .lazy_clickhouse_reader import *
 from .lazy_clickhouse_writer import *
@@ -83,6 +84,10 @@ class PIOTOperations:
     @functools.wraps(cache_parquet)
     def cache_parquet(self, *args, **kwargs) -> pl.LazyFrame:
         return cache_parquet(self._lf, *args, **kwargs)
+
+    @functools.wraps(cache_memory)
+    def cache_memory(self, *args, **kwargs) -> pl.LazyFrame:
+        return cache_memory(self._lf, *args, **kwargs)
 
     @functools.wraps(_execute_on_ray_proto)
     def execute_on_ray(self, *args, **kwargs) -> pl.LazyFrame:

--- a/polars_io_tools/io_sources/lazy_cache_memory.py
+++ b/polars_io_tools/io_sources/lazy_cache_memory.py
@@ -1,0 +1,240 @@
+"""In-memory, builder-driven cache for non-serializable LazyFrames.
+
+:func:`cache_memory` is the third member of the caching family, complementing
+:func:`~polars_io_tools.io_sources.lazy_cache.cache` and
+:func:`~polars_io_tools.io_sources.lazy_cache_parquet.cache_parquet`:
+
+======================  ==============================  ==============================  ============
+function                input                           key model                       backend
+======================  ==============================  ==============================  ============
+``cache``               ``LazyFrame`` (plan)            serialize (content-addressed)   in-memory
+``cache_parquet``       builder callable or plan        ``cache_path`` (explicit)       Parquet (disk)
+``cache_memory``        builder callable or plan        none (instance / identity)      in-memory
+======================  ==============================  ==============================  ============
+
+Unlike ``cache``, which derives its key by serializing the plan, ``cache_memory``
+holds the materialized buffer in the returned frame's own closure, so nothing is
+serialized, hashed, or looked up. This makes it usable with ``register_io_source``
+plugins whose generator closes over non-picklable state (a connection, a lock, an
+open iterator) that ``cache`` cannot serialize.
+
+The buffer is collected **once** on first row demand and replayed thereafter, so a
+consumer that references the returned frame many times — within one query, or across
+several collects — pays a single upstream execution. Polars' Common Subplan
+Elimination does not deduplicate independent references to an IO-backed source, so a
+plain lazy plan is otherwise re-executed once per reference. This is the primitive to
+reach for during complex, multi-branch evaluations where an expensive or
+non-serializable source is read from several branches and a Parquet round-trip
+(``cache_parquet``) is unwanted.
+
+Lifetime is bounded by the returned frame: the buffer is reachable only through it, so
+ordinary garbage collection reclaims the memory when the frame (and any plan embedding
+it) is dropped. There is no key, no eviction policy, and nothing to invalidate — a
+fresh call builds a fresh buffer.
+
+Thread-safe for the one-time materialization: a double-checked lock prevents concurrent
+callers from running the builder twice. After materialization the buffered
+``pl.DataFrame`` is immutable and safe to read from multiple threads.
+
+Build-once, uniformly: the builder runs **exactly once** per instance whatever the outcome.
+On success the buffer is served thereafter; on any failure — an ordinary exception (e.g. a
+data-quality raise) or a control-flow ``BaseException`` such as ``KeyboardInterrupt`` — the
+failure is recorded and re-raised (as a fresh neutral error carrying the original type name
+and message) on every subsequent collect. So a fan-out across ``pl.collect_all`` sees one
+failure, never one re-run of a failing builder per branch, and an interrupted build poisons
+the instance rather than silently re-running. There is no in-place retry — retrying means
+constructing a fresh ``cache_memory`` (a fresh call builds a fresh buffer), the same
+instance-scoped invalidation model as the success path.
+"""
+
+import threading
+from collections.abc import Callable, Iterator
+
+import polars as pl
+
+from .util import collect_lf_in_io_source, register_io_source_with_is_pure
+
+__all__ = ("cache_memory",)
+
+
+class _CachedBuildError(Exception):
+    """Raised on every collect after a ``cache_memory`` instance's one build attempt failed.
+
+    The original failure (its type name and message) is recorded once and re-raised through a
+    fresh instance of this neutral type on each subsequent collect. Storing the live exception
+    would pin its traceback — and through it the whole failed frame — alive, and re-raising one
+    shared object across collects would grow its traceback and cannot faithfully reconstruct an
+    arbitrary exception type from its message.
+    """
+
+
+def cache_memory(
+    self_or_fn: pl.LazyFrame | Callable[[], pl.LazyFrame],
+    *,
+    schema: pl.Schema | Callable[[], pl.Schema],
+) -> pl.LazyFrame:
+    """Collect a builder at most once into an in-memory buffer and replay it thereafter.
+
+    Wrapping performs no I/O and no collection; the builder runs only on first row
+    demand. With a callable ``schema``, even ``collect_schema()`` on the result avoids
+    running the builder. The first row demand collects the builder into a buffer;
+    subsequent demands (more references, more collects) replay it, so a consumer that
+    references the returned frame N times pays one upstream execution total.
+
+    Because it materializes the whole frame, downstream predicates and projections are
+    applied to the buffer *after* materialization (they are not pushed into the upstream
+    source). This is inherent to "collect once and reuse" and differs from a pass-through
+    source.
+
+    Args:
+        self_or_fn (pl.LazyFrame | Callable[[], pl.LazyFrame]): The source to memoize.
+            A zero-argument callable returning a ``LazyFrame`` (executed at most once, on
+            first row demand, and free to contain arbitrary Python: staged collects,
+            validation that raises, data-dependent control flow), or a ``LazyFrame``,
+            which is wrapped as such a callable.
+        schema (pl.Schema | Callable[[], pl.Schema]): The schema the returned frame
+            advertises. Either a ``pl.Schema`` or a zero-argument callable returning one.
+            A callable defers resolution until Polars needs it, so ``collect_schema()`` on
+            the result never forces the builder to run — useful when the schema is derived
+            from the builder's own lazy plan.
+
+    Returns:
+        pl.LazyFrame: A LazyFrame with ``schema``, backed by a generator over a one-time
+        materialization of the builder.
+
+    Raises:
+        TypeError: If ``schema`` is neither a ``pl.Schema`` nor a callable.
+        ValueError: At build time, if the materialized frame is missing a declared column
+            or a declared column's dtype does not match. Because the check runs inside the
+            io_source generator, Polars surfaces it as
+            :class:`polars.exceptions.ComputeError` at collect time (message preserved).
+    """
+    if not isinstance(schema, pl.Schema) and not callable(schema):
+        raise TypeError(f"cache_memory requires a pl.Schema or a callable, got {type(schema).__name__}")
+
+    build_frame: Callable[[], pl.LazyFrame] = self_or_fn if callable(self_or_fn) else (lambda: self_or_fn)
+
+    buffer: pl.DataFrame | None = None
+    # A cached build failure, stored as a lightweight ``(exception_type_name, message)`` record
+    # rather than the live exception object. Storing the object would pin its traceback — and
+    # through it the whole failed DataFrame — alive for the instance's lifetime, and re-raising one
+    # shared object grows its traceback on every collect. We re-raise a fresh neutral error instead.
+    build_error: tuple[str, str] | None = None
+    resolved_schema: pl.Schema | None = None
+    building = False
+    schema_lock = threading.Lock()
+    build_cond = threading.Condition()
+
+    def get_schema() -> pl.Schema:
+        nonlocal resolved_schema
+        # Resolve the (possibly callable) schema exactly once, under its own lock, so a
+        # non-deterministic callable can never advertise one schema to Polars while the buffer
+        # is reconciled against another. Polars is handed ``get_schema`` (not the raw callable),
+        # so the value it sees and the value used for reconciliation are the same memoized object.
+        with schema_lock:
+            if resolved_schema is None:
+                resolved_schema = schema() if callable(schema) else schema
+            return resolved_schema
+
+    def get_buffer() -> pl.DataFrame:
+        nonlocal buffer, building, build_error
+        with build_cond:
+            while True:
+                if buffer is not None:
+                    return buffer
+                if build_error is not None:
+                    # The build ran once and failed; that outcome is terminal for this instance.
+                    # Re-raise a fresh neutral error carrying the original type and message rather
+                    # than retrying, so a fan-out / collect_all of N branches sees one failure, not
+                    # N re-runs of a failing builder. To retry, construct a fresh cache_memory.
+                    type_name, message = build_error
+                    raise _CachedBuildError(f"{type_name}: {message}")
+                if building:
+                    # Another thread is materializing the one build. Wait and share its outcome.
+                    build_cond.wait()
+                    continue
+                # No outcome yet and nobody building: become the sole builder.
+                building = True
+                break
+
+        # Build outside the condition lock so waiters can park on ``build_cond`` while this runs.
+        # Only one thread ever reaches here (guarded by ``building`` + the terminal outcome above).
+        try:
+            built = build_frame().collect()
+            # Reconcile the materialized frame against the declared schema ONCE, here at build time.
+            # The check is deliberately asymmetric: a missing declared column or a dtype mismatch
+            # raises (either would silently corrupt results); an extra column is dropped by the
+            # select below so the declared schema stays constant. Polars does not validate yielded
+            # frames against the declared schema, so this is the only safety net.
+            declared = get_schema()
+            actual = built.schema
+            for name in declared.names():
+                if name not in actual:
+                    raise ValueError(f"cache_memory: declared column '{name}' is missing from the constructed frame")
+                if actual[name] != declared[name]:
+                    raise ValueError(f"cache_memory: column '{name}' declared as {declared[name]} but constructed frame has {actual[name]}")
+            result = built.select(declared.names())
+        except BaseException as exc:
+            # Any build failure — an ordinary Exception (e.g. a data-quality raise) or a control-flow
+            # BaseException (KeyboardInterrupt/SystemExit) — is terminal for this instance. Recording
+            # it (rather than resetting) keeps parked fan-out waiters from each launching a redundant
+            # retry, so the builder runs exactly once whatever the outcome. An interrupted build thus
+            # poisons the instance; retry by constructing a fresh cache_memory.
+            #
+            # Derive the message *before* taking the lock: a pathological ``__str__`` that raises must
+            # not abort the critical section, which would leave ``building`` stuck True and deadlock
+            # every future collect. The work under the lock is then only assignment + notify.
+            type_name = type(exc).__name__
+            try:
+                message = str(exc)
+            except BaseException:  # noqa: BLE001 - a broken __str__ must not poison the instance
+                message = "<exception message unavailable>"
+            with build_cond:
+                build_error = (type_name, message)
+                building = False
+                build_cond.notify_all()
+            raise
+
+        with build_cond:
+            buffer = result
+            building = False
+            build_cond.notify_all()
+        return result
+
+    def source_generator(
+        with_columns: list[str] | None,
+        predicate: pl.Expr | None,
+        n_rows: int | None,
+        batch_size: int | None,
+    ) -> Iterator[pl.DataFrame]:
+        # The buffer is already reconciled and projected to the declared schema (see get_buffer).
+        lf = get_buffer().lazy()
+        if predicate is not None:
+            lf = lf.filter(predicate)
+
+        # Project after the filter so predicate columns are still available to it. Without this the
+        # wrapped source would be asked for every column, which is strictly worse than the un-proxied
+        # plan.
+        if with_columns is not None:
+            requested = set(with_columns)
+            names = get_schema().names()
+            projected = [c for c in names if c in requested]
+            # Defensive: an empty projection (some Polars versions request ``with_columns=[]`` for a
+            # count-only query such as ``pl.len()``) must not collapse row cardinality — ``select([])``
+            # yields a 0-row, 0-column frame. Keep one declared column so every source row survives;
+            # the count consumer only needs the height. (On Polars 1.42.1 count pushes a single named
+            # column, so this branch is not exercised in practice — it guards against version drift.)
+            if projected:
+                lf = lf.select(projected)
+            elif names:
+                lf = lf.select(names[0])
+
+        if n_rows is not None:
+            lf = lf.head(n_rows)
+
+        yield from collect_lf_in_io_source(lf, batch_size)
+
+    # register_io_source_with_is_pure (unlike the plain register_io_source, which raises ComputeError
+    # for a callable schema) accepts a zero-arg callable schema and resolves it lazily. We hand it the
+    # memoizing ``get_schema`` so Polars and the buffer reconciliation agree on one resolved schema.
+    return register_io_source_with_is_pure(io_source=source_generator, schema=get_schema)

--- a/polars_io_tools/tests/io_sources/test_lazy_cache_memory.py
+++ b/polars_io_tools/tests/io_sources/test_lazy_cache_memory.py
@@ -1,0 +1,474 @@
+"""Unit tests for :func:`polars_io_tools.io_sources.lazy_cache_memory.cache_memory`."""
+
+import gc
+import threading
+import unittest
+import weakref
+
+import polars as pl
+import pytest
+from polars.exceptions import ComputeError
+from polars.io.plugins import register_io_source
+
+from polars_io_tools.io_sources import cache_memory
+from polars_io_tools.io_sources.util import collect_lf_in_io_source, register_io_source_with_is_pure
+
+
+def _counting_source(frame: pl.LazyFrame, counter: list) -> pl.LazyFrame:
+    """A plain (non-memoized) register_io_source that appends to ``counter`` on every scan.
+
+    Used to measure how many times the *upstream* is actually executed — the quantity
+    ``cache_memory`` is meant to collapse to one, independent of builder-call counting.
+    """
+    schema = frame.collect_schema()
+
+    def gen(with_columns, predicate, n_rows, batch_size):
+        counter.append(1)
+        lf = frame
+        if predicate is not None:
+            lf = lf.filter(predicate)
+        if with_columns is not None:
+            requested = set(with_columns)
+            lf = lf.select([c for c in schema.names() if c in requested])
+        if n_rows is not None:
+            lf = lf.head(n_rows)
+        yield from collect_lf_in_io_source(lf, batch_size)
+
+    return register_io_source_with_is_pure(io_source=gen, schema=schema)
+
+
+def _stateful_source() -> pl.LazyFrame:
+    """A register_io_source-backed frame whose generator closes over a non-picklable lock.
+
+    Reproduces issue #26: ``cache`` (which keys by serializing the plan) cannot handle
+    this source, but ``cache_memory`` can.
+    """
+    data = pl.DataFrame({"id": [1, 2, 3, 4], "value": [10, 20, 30, 40]})
+    schema = data.collect_schema()
+    lock = threading.Lock()  # non-picklable state captured in the generator's closure
+
+    def generator(with_columns, predicate, n_rows, batch_size):
+        with lock:
+            frame = data.lazy()
+        if predicate is not None:
+            frame = frame.filter(predicate)
+        if with_columns is not None:
+            frame = frame.select(with_columns)
+        yield frame.collect()
+
+    return register_io_source(io_source=generator, schema=schema)
+
+
+class TestCacheMemory(unittest.TestCase):
+    """Tests for cache_memory, which collapses N references to one upstream scan.
+
+    ``register_io_source_with_is_pure`` does no declared-vs-yielded validation, so
+    cache_memory's own reconciliation is the entire safety net against schema drift.
+    """
+
+    @staticmethod
+    def _frame() -> pl.LazyFrame:
+        return pl.LazyFrame({"a": pl.Series([1, 2], dtype=pl.Int64), "b": ["x", "y"]})
+
+    def test_collects_once_across_n_references(self):
+        """The upstream is scanned exactly once even when the frame is referenced N times.
+
+        Not merely that the builder is called once, but that the *collected buffer* is
+        reused, so a consumer that references the frame many times pays one upstream
+        execution total.
+        """
+        scans: list = []
+        frame = self._frame()
+        lf = cache_memory(lambda: _counting_source(frame, scans), schema=frame.collect_schema())
+
+        # Referenced twice in one plan, plus two independent collects.
+        pl.concat([lf, lf], how="vertical").collect()
+        lf.collect()
+        lf.collect()
+
+        self.assertEqual(len(scans), 1)
+
+    def test_builder_called_once(self):
+        """The builder itself is invoked at most once."""
+        calls = []
+
+        def build():
+            calls.append(1)
+            return frame
+
+        frame = self._frame()
+        lf = cache_memory(build, schema=frame.collect_schema())
+
+        pl.concat([lf, lf], how="vertical").collect()
+        lf.collect()
+
+        self.assertEqual(len(calls), 1)
+
+    def test_accepts_plain_lazyframe(self):
+        """A LazyFrame passed directly is wrapped as a builder and still collapses references."""
+        scans: list = []
+        frame = self._frame()
+        source = _counting_source(frame, scans)
+        lf = cache_memory(source, schema=frame.collect_schema())
+
+        pl.concat([lf, lf], how="vertical").collect()
+        lf.collect()
+
+        self.assertEqual(len(scans), 1)
+
+    def test_varying_predicate_across_collects_correct(self):
+        """Different predicates across collects each return the correctly filtered rows."""
+        frame = self._frame()
+        lf = cache_memory(lambda: frame, schema=frame.collect_schema())
+
+        self.assertEqual(lf.filter(pl.col("a") < 2).collect()["a"].to_list(), [1])
+        self.assertEqual(lf.filter(pl.col("a") >= 2).collect()["a"].to_list(), [2])
+
+    def test_varying_projection_across_collects(self):
+        """Different projections across collects each return the correct columns."""
+        frame = self._frame()
+        lf = cache_memory(lambda: frame, schema=frame.collect_schema())
+
+        self.assertEqual(lf.select("b").collect().columns, ["b"])
+        self.assertEqual(lf.select("a").collect().columns, ["a"])
+
+    def test_callable_schema_resolved_without_running_builder(self):
+        """A callable schema lets collect_schema() resolve columns without running the builder."""
+        calls = []
+        frame = self._frame()
+
+        def build():
+            calls.append(1)
+            return frame
+
+        lf = cache_memory(build, schema=lambda: frame.collect_schema())
+
+        self.assertEqual(lf.collect_schema().names(), ["a", "b"])
+        self.assertEqual(len(calls), 0)
+
+    def test_missing_declared_column_raises(self):
+        """A constructed frame lacking a declared column must raise, naming the column."""
+        schema = self._frame().collect_schema()
+        lf = cache_memory(lambda: self._frame().drop("b"), schema=schema)
+
+        # The reconciliation ValueError is raised inside the source generator, so Polars
+        # surfaces it as ComputeError (message preserved).
+        with pytest.raises(ComputeError, match="'b'"):
+            lf.collect()
+
+    def test_declared_dtype_mismatch_raises(self):
+        """A constructed frame whose dtype drifted from the declaration must raise."""
+        schema = self._frame().collect_schema()
+        lf = cache_memory(lambda: self._frame().with_columns(pl.col("a").cast(pl.Int32)), schema=schema)
+
+        with pytest.raises(ComputeError, match="'a'"):
+            lf.collect()
+
+    def test_extra_column_dropped(self):
+        """A constructed frame with an extra column keeps the declared schema constant."""
+        schema = self._frame().collect_schema()
+        lf = cache_memory(lambda: self._frame().with_columns(pl.lit(1).alias("extra")), schema=schema)
+
+        self.assertEqual(lf.collect().columns, ["a", "b"])
+
+    def test_non_schema_non_callable_rejected(self):
+        """A plain dict (neither pl.Schema nor callable) is rejected up front."""
+        with pytest.raises(TypeError, match="pl.Schema or a callable"):
+            cache_memory(self._frame(), schema={"a": pl.Int64})
+
+    def test_count_only_query_returns_true_row_count(self):
+        """A count-only query, where Polars requests zero columns, still counts every row.
+
+        Polars pushes ``with_columns=[]`` for ``pl.len()``. The projection logic must keep
+        yielding one row per source row rather than collapsing to a 0-width, 0-row frame.
+        """
+        frame = self._frame()
+        lf = cache_memory(lambda: frame, schema=frame.collect_schema())
+
+        self.assertEqual(lf.select(pl.len()).collect().item(), frame.collect().height)
+
+    def test_empty_projection_matches_plain_polars(self):
+        """An explicitly empty projection behaves exactly as on a plain LazyFrame."""
+        frame = self._frame()
+        lf = cache_memory(lambda: frame, schema=frame.collect_schema())
+
+        self.assertEqual(lf.select([]).collect().shape, frame.select([]).collect().shape)
+
+    def test_non_serializable_source_memoized(self):
+        """A non-serializable (lock-closing) plugin source works, unlike ``cache``.
+
+        This is issue #26's core motivation: the plan cannot be serialized, so a
+        content-addressed cache cannot key it, but cache_memory needs no key.
+        """
+        src = _stateful_source()
+        # The source itself cannot be serialized (what `cache` would attempt for its key).
+        with pytest.raises(Exception):
+            src.serialize()
+
+        lf = cache_memory(_stateful_source, schema=pl.Schema({"id": pl.Int64, "value": pl.Int64}))
+        out = pl.concat([lf, lf], how="vertical").collect()
+        self.assertEqual(out.height, 8)
+        self.assertEqual(lf.filter(pl.col("id") == 1).collect()["value"].to_list(), [10])
+
+    def test_collects_once_across_collect_all_fanout(self):
+        """A frame fanned out into many branches collected via ``pl.collect_all`` builds once.
+
+        This is the multi-branch / ``collect_all`` use case: several *separate* plans that each
+        reference the same cache_memory frame are collected in one (parallel) pass. The
+        double-checked lock must still collapse them to a single upstream execution even though
+        Polars runs the branches concurrently across its thread pool.
+        """
+        counter: list = []
+        base = pl.DataFrame({"id": [1, 2, 3, 4], "v": [10, 20, 30, 40]})
+
+        def build():
+            counter.append(1)
+            return base.lazy()
+
+        lf = cache_memory(build, schema=base.collect_schema())
+
+        branches = [lf.filter(pl.col("id") == i).select(pl.col("v").sum()) for i in range(1, 5)]
+        branches.append(lf.group_by("id").agg(pl.col("v").mean()))
+        results = pl.collect_all(branches)
+
+        self.assertEqual(len(counter), 1)
+        # Sanity: each branch still returns the correct filtered slice.
+        self.assertEqual(results[0].item(), 10)
+
+        # A second, independent collect_all pass reuses the buffer (no rebuild).
+        pl.collect_all([lf.select(pl.len()), lf.filter(pl.col("id") > 2)])
+        self.assertEqual(len(counter), 1)
+
+    def test_buffer_released_when_frame_dropped(self):
+        """The collected buffer is reclaimed by GC once the returned frame is dropped.
+
+        The buffer lives only in the returned frame's closure, so nothing outlives it. A
+        sentinel embedded in the materialized buffer (via an Object-dtype column) must be
+        weakref-dead after the frame is dropped and a collection runs.
+        """
+
+        class Sentinel:
+            pass
+
+        holder: dict = {}
+
+        def build():
+            sentinel = Sentinel()
+            holder["ref"] = weakref.ref(sentinel)
+            return pl.DataFrame(
+                {"a": [1, 2], "obj": [sentinel, sentinel]},
+                schema={"a": pl.Int64, "obj": pl.Object},
+            ).lazy()
+
+        lf = cache_memory(build, schema=pl.Schema({"a": pl.Int64, "obj": pl.Object}))
+        lf.collect()  # force the one-time build so the buffer holds the sentinel
+
+        self.assertIsNotNone(holder["ref"](), "sentinel should be alive while the frame is held")
+
+        del lf
+        gc.collect()
+
+        self.assertIsNone(holder["ref"](), "buffer (and its contents) must be released once the frame is dropped")
+
+    def test_failed_build_not_amplified_across_collect_all(self):
+        """A failing build runs once per episode, not once per fanned-out branch.
+
+        Regression for the fan-out failure path: without episode sharing, every branch parked on
+        the lock would re-run the failing builder (N failed builds for N branches in one
+        ``collect_all``). Concurrent waiters must instead share the single build's exception.
+        """
+        attempts: list = []
+
+        def build():
+            attempts.append(1)
+            raise ValueError("boom")
+
+        lf = cache_memory(build, schema=pl.Schema({"a": pl.Int64}))
+        branches = [lf.filter(pl.col("a") == i) for i in range(64)]
+
+        with pytest.raises(ComputeError, match="boom"):
+            pl.collect_all(branches)
+
+        # One build episode for the whole collect_all pass, not one per branch.
+        self.assertEqual(len(attempts), 1)
+
+    def test_failed_build_is_terminal_and_cached(self):
+        """A failed build runs once; the exception is cached and re-raised on later collects.
+
+        Retry is by constructing a fresh cache_memory, matching the success path's
+        instance-scoped model. This is what keeps a failing builder from being re-run once
+        per branch under fan-out / collect_all.
+        """
+        state = {"calls": 0}
+        frame = self._frame()
+
+        def build():
+            state["calls"] += 1
+            raise ValueError("transient")
+
+        lf = cache_memory(build, schema=frame.collect_schema())
+
+        with pytest.raises(ComputeError, match="transient"):
+            lf.collect()
+        with pytest.raises(ComputeError, match="transient"):
+            lf.collect()
+
+        # Built once, cached failure re-raised on the second collect.
+        self.assertEqual(state["calls"], 1)
+
+        # A fresh instance retries from scratch.
+        state["ok"] = frame
+        lf2 = cache_memory(lambda: frame, schema=frame.collect_schema())
+        self.assertEqual(lf2.collect()["a"].to_list(), [1, 2])
+
+    def test_failed_build_does_not_retain_frame(self):
+        """A cached failure must not pin the failed DataFrame (via a stored exception traceback).
+
+        Exercises the exact retention path: reconciliation fails *after* ``build`` returns a frame
+        holding a sentinel, so the materialized ``built`` frame is live at the raise site. The
+        cached failure must be a lightweight record, not the live exception whose traceback pins it.
+        """
+
+        class Sentinel:
+            pass
+
+        holder: dict = {}
+
+        def build():
+            sentinel = Sentinel()
+            holder["ref"] = weakref.ref(sentinel)
+            # 'a' drifts Int64 -> Int32 so reconciliation raises inside get_buffer, where ``built``
+            # (carrying the sentinel in its Object column) is the live materialized frame.
+            return pl.DataFrame(
+                {"a": pl.Series([1, 2], dtype=pl.Int32), "obj": [sentinel, sentinel]},
+                schema={"a": pl.Int32, "obj": pl.Object},
+            ).lazy()
+
+        lf = cache_memory(build, schema=pl.Schema({"a": pl.Int64, "obj": pl.Object}))
+        with pytest.raises(ComputeError, match="'a'"):
+            lf.collect()
+        # A second collect re-raises the cached failure without rebuilding.
+        with pytest.raises(ComputeError, match="'a'"):
+            lf.collect()
+
+        gc.collect()
+        # The frame built during the failed attempt must not be retained by the cached error.
+        self.assertIsNone(holder["ref"](), "failed build must not be retained by the cached error")
+
+    def test_keyboard_interrupt_build_is_terminal(self):
+        """An interrupted build is terminal (not retried per branch); a fresh instance retries.
+
+        Recording every failure — including a control-flow BaseException — is what keeps a
+        fan-out / collect_all from re-running the builder once per parked waiter. The interrupt
+        propagates on the first collect; later collects re-raise a neutral cached error.
+        """
+        state = {"calls": 0}
+        frame = self._frame()
+
+        def build():
+            state["calls"] += 1
+            raise KeyboardInterrupt
+
+        lf = cache_memory(build, schema=frame.collect_schema())
+
+        with pytest.raises((KeyboardInterrupt, ComputeError)):
+            lf.collect()
+        # Subsequent collect re-raises the cached failure (as ComputeError) without rebuilding.
+        with pytest.raises(ComputeError):
+            lf.collect()
+        self.assertEqual(state["calls"], 1)
+
+        # A fresh instance retries from scratch.
+        lf2 = cache_memory(lambda: frame, schema=frame.collect_schema())
+        self.assertEqual(lf2.collect()["a"].to_list(), [1, 2])
+
+    @pytest.mark.timeout(15)
+    def test_unprintable_exception_does_not_deadlock(self):
+        """A builder exception whose ``__str__`` raises must still publish a terminal outcome.
+
+        Regression: deriving the cached message inside the lock would abort the critical section
+        before clearing ``building``, hanging every later collect. The message must be derived
+        before the lock, with a fallback that does not call ``str``.
+        """
+        calls: list = []
+
+        class BadStringError(Exception):
+            def __str__(self):
+                raise RuntimeError("cannot format")
+
+        def build():
+            calls.append(1)
+            raise BadStringError
+
+        lf = cache_memory(build, schema=pl.Schema({"a": pl.Int64}))
+
+        with pytest.raises(ComputeError):
+            lf.collect()
+        # Must not hang: the terminal state was published despite the broken __str__.
+        with pytest.raises(ComputeError):
+            lf.collect()
+        self.assertEqual(len(calls), 1)
+
+    def test_failed_build_not_amplified_for_base_exception(self):
+        """A control-flow failure also collapses to one build across a collect_all fan-out."""
+        attempts: list = []
+
+        def build():
+            attempts.append(1)
+            raise KeyboardInterrupt
+
+        lf = cache_memory(build, schema=pl.Schema({"a": pl.Int64}))
+        branches = [lf.filter(pl.col("a") == i) for i in range(64)]
+
+        with pytest.raises((KeyboardInterrupt, ComputeError)):
+            pl.collect_all(branches)
+
+        self.assertEqual(len(attempts), 1)
+
+    def test_empty_projection_preserves_row_count(self):
+        """A directly-pushed empty projection must not collapse row cardinality (count-query guard).
+
+        Some Polars versions may push ``with_columns=[]`` for a count-only query. The generator
+        must still yield one row per source row. Invoked directly because Polars 1.42.1 pushes a
+        named column for ``pl.len()`` and never reaches this branch through normal use.
+        """
+        frame = self._frame()
+        captured: dict = {}
+
+        def build():
+            return frame
+
+        # Capture the underlying io_source generator to invoke the empty-projection path directly.
+        real_register = register_io_source_with_is_pure
+
+        def _capture(io_source, schema, **kwargs):
+            captured["gen"] = io_source
+            return real_register(io_source, schema, **kwargs)
+
+        import polars_io_tools.io_sources.lazy_cache_memory as mod
+
+        orig = mod.register_io_source_with_is_pure
+        mod.register_io_source_with_is_pure = _capture
+        try:
+            cache_memory(build, schema=frame.collect_schema())
+        finally:
+            mod.register_io_source_with_is_pure = orig
+
+        rows = sum(df.height for df in captured["gen"](with_columns=[], predicate=None, n_rows=None, batch_size=None))
+        self.assertEqual(rows, frame.collect().height)
+
+    def test_callable_schema_resolved_once(self):
+        """A callable schema is resolved exactly once even across schema queries and collects."""
+        calls = []
+        frame = self._frame()
+
+        def sch():
+            calls.append(1)
+            return frame.collect_schema()
+
+        lf = cache_memory(lambda: frame, schema=sch)
+        lf.collect_schema()
+        lf.collect()
+        lf.collect()
+
+        self.assertEqual(len(calls), 1)


### PR DESCRIPTION
## Summary

Adds `cache_memory`, a third caching primitive alongside `cache` and `cache_parquet`, closing the gap described in #26: an **in-memory, builder-driven** cache that does not require the plan to be serializable.

|  | input | key model | backend |
|---|---|---|---|
| `cache` | `LazyFrame` (plan) | serialize (content-addressed) | in-memory |
| `cache_parquet` | builder or plan (+ `schema`) | `cache_path` (explicit) | Parquet (disk) |
| **`cache_memory`** | **builder or plan (+ `schema`)** | **none (instance / identity)** | **in-memory** |

`cache` derives its key by serializing the plan, so it cannot key a `LazyFrame` backed by `register_io_source` whose generator closes over non-picklable state (a connection, a lock, an open iterator). `cache_parquet` accepts a builder + schema and needs no serialization, but only has a disk backend. `cache_memory` fills the remaining corner: **builder-callable input, no plan serialization, in-memory backend**.

## Behaviour

It collects the builder **at most once** into a closure-held buffer and replays it on every reference or collect, so a source read from many branches of a multi-branch evaluation (including `pl.collect_all`) executes upstream exactly once instead of once per reference. There is no key — reuse happens through the returned frame's identity, and the buffer is reclaimed by garbage collection when that frame is dropped.

- Construction and `collect_schema()` (with a callable `schema`) do no I/O and no collect; the builder runs only on first row demand.
- The one-time build is thread-safe; concurrent first-collects fanned out across `pl.collect_all` share a single build.
- The build outcome is **terminal**: any failure is recorded and re-raised on subsequent collects (as a neutral error carrying the original type and message), so a failing builder is not re-run per branch. Retry by constructing a fresh `cache_memory`.
- The collected frame is reconciled against the declared schema once (missing column or dtype mismatch raises; extras are dropped).

## API

- Top-level: `cache_memory(build_or_lf, *, schema)`
- Namespace: `lf.piot.cache_memory(*, schema)`

## Test plan

- [x] New unit tests in `tests/io_sources/test_lazy_cache_memory.py` (23 cases): collect-once across references and `pl.collect_all` fan-out, thread-safe single build, buffer released on GC, non-serializable plugin source, callable-schema resolution without building, terminal/no-amplification failure semantics, no frame/traceback retention on failure, schema reconciliation, and empty-projection cardinality.
- [x] `ruff check` and `ruff format --check` clean.
- [x] Full `io_sources` suite passes.

Closes #26.