### PR TITLE
Add opt-in partitioned reads to scan_db

### DIFF
--- a/docs/wiki/Reading-and-Writing-Data.md
+++ b/docs/wiki/Reading-and-Writing-Data.md
@@ -67,6 +67,67 @@ example SQL Server can still seek on `CAST(datetime AS date)`) while others fall
 full scan. When a filtered column is indexed and on a hot path, prefer filtering the
 physical column directly over its cast form.
 
+## Speed up a large SQL read by partitioning it
+
+When a scan-like extract is bounded by an indexed column, a single ODBC cursor is often the
+bottleneck. Pass `partitions=` and `scan_db` splits the read into independent slices and pulls
+them over parallel connections, concatenating the results in order. Build the slices from the
+filter you push down with `by_time`, `by_value`, or `by_range`:
+
+```python
+from polars_io_tools import scan_db, by_time
+
+lf = scan_db(
+    "SELECT * FROM daily_prices",
+    connection="Driver={PostgreSQL};Server=db.example.com;Database=mkt;Uid=reader;******",
+    partitions=by_time("price_date", every="1mo"),
+)
+
+# One slice per month, taken from the pushed-down date range:
+result = lf.filter(
+    (pl.col("price_date") >= pl.date(2025, 1, 1)) & (pl.col("price_date") < pl.date(2025, 7, 1))
+).collect()
+```
+
+- `by_time(column, every=)` — calendar windows; `every` is an interval string (`"1mo"`, `"2w"`,
+  `"5d"`, `"1q"`, `"1y"`) or an integer number of days.
+- `by_value(column, values=None)` — one slice per discrete value; with `values=None` the values
+  are read from the `IN` filter you push down.
+- `by_range(column, every=)` — fixed-width numeric buckets over the pushed-down range.
+
+How many slices run at once is capped by a process-wide SQL connection budget
+(`POLARS_IO_TOOLS_MAX_SQL_CONNECTIONS`; default `min(pl.thread_pool_size(), 8)` — a modest 8 on a
+normal machine, self-throttling to 1 in fan-out clusters that pin `POLARS_MAX_THREADS=1`, since
+these reads are IO-bound and the cap is a connection budget, not the CPU thread pool); pass
+`max_concurrency=` to throttle below it on a busy server. Partitioning is fully opt-in — with no
+`partitions=`, or when a partitioner cannot derive a bounded split, `scan_db` runs the query over
+a single connection. Prefer a handful of medium slices over many tiny ones: each slice is a
+separate query with its own planning and round-trip cost.
+
+For hand-built slices, pass an iterable of `ReadPartition(predicate, key)`. Predicates that
+translate to SQL are pushed to the database; any part that cannot (for example an arbitrary
+Python UDF) is still enforced client-side, so each slice stays exact.
+
+Rows are yielded in completion order (whichever slice's batches arrive first), which is not
+deterministic; if you need a specific order, sort in Polars with `.sort()` after the read. If your
+query has a top-level `ORDER BY`, partitioning can't re-establish it across slices, so `scan_db`
+logs a warning and ignores it (the rows are still correct) — again, `.sort()` after the read.
+Clauses that would change the *result* under partitioning — a top-level `LIMIT`/`OFFSET`/`TOP`/`FETCH`,
+`QUALIFY`, or a window function — raise instead; apply them in Polars after the read (`.head()`, etc.),
+or read without `partitions=`.
+
+Each slice is streamed batch-by-batch over its own connection, so peak memory stays proportional to
+the connection budget times the arrow batch size — a large slice is never fully buffered in memory.
+
+Each slice opens its own ODBC connection, so a read split into many slices pays that many connects.
+If connect overhead dominates (many small slices, or TLS/Kerberos on every connect), prefer a few
+larger slices, and/or let the ODBC driver manager recycle physical connections by calling
+[`arrow_odbc.enable_odbc_connection_pooling()`](https://arrow-odbc.readthedocs.io/) once before your
+first read — pooled connects skip the handshake. This is a process-global arrow-odbc / driver-manager
+setting (it affects all ODBC use in your process and reuses physical connections, so session-scoped
+state such as temp tables can persist across them), so it is left to the caller rather than toggled
+by `scan_db`.
+
 ## Read from ClickHouse
 
 `scan_clickhouse` streams query results over ClickHouse's HTTP interface as Arrow IPC.

--- a/polars_io_tools/io_sources/lazy_sql_reader.py
+++ b/polars_io_tools/io_sources/lazy_sql_reader.py
@@ -1,4 +1,9 @@
+import concurrent.futures
 import logging
+import os
+import queue
+import threading
+from collections.abc import Iterable
 from functools import lru_cache
 from typing import Any
 
@@ -6,6 +11,7 @@ import polars as pl
 from sqlglot import exp, parse_one
 from sqlglot.dialects.dialect import Dialect
 
+from .partitions import Partitioner, ReadPartition, as_partition_list, retained_columns
 from .sql_dialects import MSSQL
 from .sql_utils import (
     apply_polars_io_source_exprs,
@@ -19,6 +25,113 @@ __all__ = ("scan_db",)
 
 # Configure logging
 log = logging.getLogger(__name__)
+
+# Process-wide budget for concurrent SQL connections. Partition reads are IO-bound (each worker
+# is mostly blocked on the database), so the right cap is an IO connection budget, not the CPU
+# compute pool. Tune with `POLARS_IO_TOOLS_MAX_SQL_CONNECTIONS`; when unset the default is
+# `min(pl.thread_pool_size(), 8)` -- a modest 8 on a normal machine, but self-throttling to 1 in
+# fan-out clusters that pin `POLARS_MAX_THREADS=1` per worker (where the real risk is N workers x
+# N connections). This treats `POLARS_MAX_THREADS` only as a downward ceiling / "be gentle"
+# signal, not as a compute-sizing driver. The shared executor is the global governor so
+# concurrent scans cannot collectively oversubscribe. The budget is parsed lazily (on first
+# parallel use) so a malformed value fails there, naming the variable, rather than breaking
+# `import polars_io_tools` for everyone -- including users who never touch `scan_db`.
+_SQL_CONNECTIONS_ENV = "POLARS_IO_TOOLS_MAX_SQL_CONNECTIONS"
+_SQL_EXECUTOR: concurrent.futures.ThreadPoolExecutor | None = None
+_SQL_CONNECTION_BUDGET: int | None = None
+_SQL_EXECUTOR_LOCK = threading.Lock()
+
+
+def _resolve_sql_connection_budget() -> int:
+    raw = os.environ.get(_SQL_CONNECTIONS_ENV)
+    if raw is None or not raw.strip():
+        return min(pl.thread_pool_size(), 8)
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        raise ValueError(f"{_SQL_CONNECTIONS_ENV} must be a positive integer, got {raw!r}.") from None
+    if value < 1:
+        raise ValueError(f"{_SQL_CONNECTIONS_ENV} must be a positive integer (>= 1), got {raw!r}.")
+    return value
+
+
+def _get_sql_executor() -> tuple[concurrent.futures.ThreadPoolExecutor, int]:
+    """Return the shared SQL thread pool and its connection budget (``k``).
+
+    Both are created together under the lock so the pool size and the per-scan concurrency cap
+    are always the same authoritative number.
+    """
+    global _SQL_EXECUTOR, _SQL_CONNECTION_BUDGET
+    with _SQL_EXECUTOR_LOCK:
+        if _SQL_EXECUTOR is None:
+            _SQL_CONNECTION_BUDGET = _resolve_sql_connection_budget()
+            _SQL_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=_SQL_CONNECTION_BUDGET)
+        return _SQL_EXECUTOR, _SQL_CONNECTION_BUDGET
+
+
+# How long a producer/consumer blocks on a full/empty queue before re-checking the ``stop`` event
+# (cancellation) or a worker's future (abnormal termination). Only affects cleanup/failure latency,
+# never steady-state throughput (an unblocked put/get returns immediately).
+_QUEUE_POLL_SECONDS = 0.1
+
+
+class _SliceDone:
+    """Terminal marker a worker puts on its queue when it has streamed a slice cleanly."""
+
+    __slots__ = ("idx",)
+
+    def __init__(self, idx: int) -> None:
+        self.idx = idx
+
+
+def _unwrap_top(node: exp.Expression) -> exp.Expression:
+    """Unwrap parenthesized / subquery roots to the effective top-level query node."""
+    while isinstance(node, (exp.Subquery, exp.Paren)) and node.this is not None:
+        node = node.this
+    return node
+
+
+def _top_candidates(parsed: exp.Expression) -> list[exp.Expression]:
+    """Query node(s) whose clauses apply to the final result.
+
+    For a set operation (UNION/INTERSECT/EXCEPT) this includes the last branch, since dialects
+    differ on whether a trailing ORDER BY/LIMIT/OFFSET/FETCH hangs off the set node or its final
+    SELECT. A clause nested inside a FROM subquery is the user's own semantics and is not included.
+    """
+    top = _unwrap_top(parsed)
+    candidates = [top]
+    if isinstance(top, exp.SetOperation) and top.expression is not None:
+        candidates.append(_unwrap_top(top.expression))
+    return candidates
+
+
+def _partition_unsafe_clause(parsed: exp.Expression) -> str | None:
+    """Name a top-level clause that makes a *partitioned* read return wrong rows, else ``None``.
+
+    Each slice runs ``SELECT * FROM (<query>) AS t WHERE <bound>``, so a top-level
+    ``LIMIT``/``TOP``/``FETCH``/``OFFSET`` is applied *before* the slice bound (each slice returns a
+    different subset of the same prefix), and ``QUALIFY``/window functions are recomputed over the
+    whole input per slice. ``ORDER BY`` is handled separately (a warning -- it only loses global
+    order, the row set is still correct). Windows/QUALIFY are matched anywhere; the row-limiting
+    clauses are matched at the (unwrapped) top level only, since a nested subquery's own ``LIMIT``
+    is part of the user's query semantics.
+    """
+    if parsed.find(exp.Window) is not None:
+        return "a window function"
+    if parsed.find(exp.Qualify) is not None:
+        return "QUALIFY"
+    for node in _top_candidates(parsed):
+        if node.args.get("limit") is not None:
+            return "LIMIT/TOP"
+        if node.args.get("fetch") is not None:
+            return "FETCH"
+        if node.args.get("offset") is not None:
+            return "OFFSET"
+    return None
+
+
+def _has_top_level_order(parsed: exp.Expression) -> bool:
+    return any(node.args.get("order") is not None for node in _top_candidates(parsed))
 
 
 @lru_cache(None)
@@ -92,7 +205,16 @@ def get_schema_from_query_odbc(
 
 
 def scan_db(
-    query: str, connection: str, fetch_size: int = 10000, cast_map: dict[str, Any] | None = None, description: str | None = None, **kwargs
+    query: str,
+    connection: str,
+    fetch_size: int = 10000,
+    cast_map: dict[str, Any] | None = None,
+    *,
+    partitions: "Partitioner | Iterable[ReadPartition] | None" = None,
+    max_partitions: int = 512,
+    max_concurrency: int | None = None,
+    description: str | None = None,
+    **kwargs,
 ) -> pl.LazyFrame:
     """
     Create a LazyFrame from a SQL query with predicate pushdown support.
@@ -102,6 +224,17 @@ def scan_db(
     This function creates a LazyFrame that will execute SQL queries against the provided
     connection with optimized predicate pushdown. Filters applied to the LazyFrame will
     be translated back to SQL and pushed to the database.
+
+    When ``partitions`` is set, the reader splits the query into independent slices and pulls
+    them over parallel connections, streaming each slice's batches as they arrive. This can
+    dramatically speed up large, scan-like extracts whose single-cursor transfer is the
+    bottleneck. It is fully opt-in: with ``partitions=None`` the behaviour is identical to a
+    plain single scan.
+
+    Rows are yielded in completion order, which is not deterministic; apply a Polars ``.sort()``
+    after the read if you need a specific order. A top-level ``ORDER BY`` in ``query`` is honoured
+    only for an unpartitioned read (a single connection) -- under partitioning it is dropped with a
+    warning, since each slice is read independently.
 
     Args:
         query (str): The SQL query to execute
@@ -123,12 +256,27 @@ def scan_db(
             optimize specific conversions (for example SQL Server seeks on ``CAST(datetime AS date)``) \
             while others fall back to a scan. For a hot path on a large indexed table, prefer a \
             filter expressed directly on the physical column instead of the cast one.
+        partitions (Partitioner | Iterable[ReadPartition] | None, default None): How to split the read. \
+            Pass a partitioner from :mod:`polars_io_tools.io_sources.partitions` (``by_time``, ``by_value``, \
+            ``by_range``) to derive slices from the filter pushed down at scan time, or an explicit iterable \
+            of :class:`ReadPartition` for hand-built slices. Each slice becomes one query on its own \
+            connection; any part of a slice's predicate that cannot be pushed to SQL is enforced \
+            client-side. When a partitioner cannot derive a bounded split, the query runs unpartitioned.
+        max_partitions (int, default 512): Guardrail -- if partitioning would produce more than this \
+            many slices, raise (raise this limit or coarsen the partitions).
+        max_concurrency (int | None, default None): Optional cap on the number of partitions pulled \
+            simultaneously. Hard-capped at the process-wide SQL connection budget \
+            (``POLARS_IO_TOOLS_MAX_SQL_CONNECTIONS``; default ``min(pl.thread_pool_size(), 8)``, which \
+            self-throttles in fan-out clusters that pin ``POLARS_MAX_THREADS=1``). Use it to throttle \
+            *below* that on a shared server. None means use the full budget.
         description: Optional free-form description of this source instance, attached to its OpenTelemetry span (``explain_detail``).
         **kwargs: Additional arguments for the database connector
 
     Returns:
         pl.LazyFrame: A Polars LazyFrame with predicate pushdown support
     """
+
+    conn_string = connection if isinstance(connection, str) else str(connection)
 
     def _fetch_info_needing_connection() -> tuple[
         dict[str, pl.DataType],
@@ -149,6 +297,10 @@ def scan_db(
 
     schema, parsed_query, dialect = _fetch_info_needing_connection()
 
+    # Keep the raw user AST (before any cast_map wrapping) for the partition-safety guard: a
+    # top-level ORDER BY/LIMIT/window is nested away once we wrap, so it must be checked here.
+    original_parsed_query = parsed_query.copy()
+
     if cast_map:
         unknown = [name for name in cast_map if name not in schema]
         if unknown:
@@ -157,6 +309,78 @@ def scan_db(
         # a cast column push down to the database instead of stalling above a client cast.
         parsed_query = wrap_query_with_casts(parsed_query, dialect, list(schema), cast_map)
         schema = {name: cast_map.get(name, dtype) for name, dtype in schema.items()}
+
+    if isinstance(partitions, Partitioner):
+        if partitions.on not in schema:
+            raise ValueError(f"partition column {partitions.on!r} is not in the query schema {list(schema)}")
+    elif partitions is not None:
+        # Materialise an explicit iterable once so re-collecting the LazyFrame (whose source
+        # generator runs per collect) does not exhaust a bare generator on the first pass.
+        partitions = list(partitions)
+
+    def _select_cols(df: pl.DataFrame, with_columns: list[str] | None) -> pl.DataFrame:
+        if with_columns is not None:
+            wanted = set(with_columns)
+            return df.select(col for col in schema if col in wanted)
+        return df
+
+    def _build_sql(
+        predicate: pl.Expr | None,
+        with_columns: list[str] | None,
+        n_rows: int | None,
+        batch_size: int | None,
+    ) -> str:
+        # Reuse the shared subquery machinery (MSSQL ORDER BY / OPTION hoisting, identifier
+        # quoting) for both the pushed predicate and any partition bound folded into it.
+        final_query_expr = apply_polars_io_source_exprs(parsed_query.copy(), dialect, with_columns, predicate, n_rows, batch_size)
+        return final_query_expr.transform(fix_three_part_identifiers).sql(dialect=dialect)
+
+    def _read(sql: str, batch_size: int | None):
+        from arrow_odbc import read_arrow_batches_from_odbc
+
+        return read_arrow_batches_from_odbc(
+            query=sql,
+            batch_size=fetch_size if batch_size is None else batch_size,
+            connection_string=conn_string,
+            **kwargs,
+        )
+
+    def _process_batch(record_batch, client_predicate: pl.Expr | None, keep_columns: list[str] | None) -> pl.DataFrame:
+        """Turn one arrow batch into an exact, projected DataFrame.
+
+        ``client_predicate`` (the pushed predicate ANDed with any partition bound) is reapplied
+        client-side so the slice is exact even if only part of it translated to SQL -- this is
+        what keeps partitions disjoint. ``keep_columns`` are the caller's requested columns; any
+        extra columns retained only to evaluate the predicate are then dropped.
+        """
+        df = pl.DataFrame(record_batch)
+        if client_predicate is not None:
+            df = df.filter(client_predicate)
+        return _select_cols(df, keep_columns)
+
+    def _stream_slice(
+        idx: int, sql: str, client_predicate: pl.Expr | None, batch_size: int | None, keep_columns: list[str] | None, put, stop: threading.Event
+    ) -> None:
+        """Worker body: stream one slice's batches into a bounded queue via ``put``.
+
+        Batches are pushed one at a time (never accumulated into a whole-slice list), so peak
+        memory stays ``O(k x batch_size)`` regardless of how many rows a slice has. ``put`` blocks
+        when the queue is full (backpressure) and returns ``False`` once ``stop`` is set, at which
+        point the worker exits promptly. The worker is stop-checked at batch boundaries only:
+        an already-issued ODBC fetch cannot be interrupted mid-flight (rely on ``query_timeout_sec``
+        for a hung query). On error the exception propagates and is carried by the worker's future.
+        """
+        try:
+            if stop.is_set():
+                return
+            for record_batch in _read(sql, batch_size):
+                if stop.is_set():
+                    return
+                if not put(_process_batch(record_batch, client_predicate, keep_columns)):
+                    return
+            put(_SliceDone(idx))
+        except Exception as e:
+            raise RuntimeError(f"scan_db failed executing partition slice {idx}:\n{sql}") from e
 
     # Create the generator function for our custom IO source
     def source_generator(
@@ -168,57 +392,166 @@ def scan_db(
         # Short-circuit: if the caller already knows zero rows are needed
         # (e.g. from head(0) on a contradictory filter), skip the query entirely.
         if n_rows == 0:
-            empty = pl.DataFrame({}, schema=schema)
-            if with_columns is not None:
-                empty = empty.select(col for col in schema if col in set(with_columns))
-            yield empty
+            yield _select_cols(pl.DataFrame({}, schema=schema), with_columns)
             return
 
-        # Generate a new SQL query by combining the original query with the predicate
-        query_copy = parsed_query.copy()
-        final_query_expr = apply_polars_io_source_exprs(query_copy, dialect, with_columns, predicate, n_rows, batch_size)
-        # Convert back to SQL string
-        final_sql = final_query_expr.sql(dialect=dialect)
-        log.debug(f"Executing SQL with pushdown: {final_sql}")
+        # Resolve the partition slices. ``as_partition_list`` distinguishes three cases:
+        #   None -> a partitioner could not derive a bounded split (fall back to one query),
+        #   []   -> a known-empty partition set (yield nothing),
+        #   list -> concrete slices.
+        partition_list = as_partition_list(partitions, predicate) if partitions is not None else None
 
-        # Create a connection string if needed
-        conn_string = connection if isinstance(connection, str) else str(connection)
-        try:
-            from arrow_odbc import read_arrow_batches_from_odbc
-
-            # Use arrow_odbc directly to fetch results
-            batch_reader = read_arrow_batches_from_odbc(
-                query=final_sql,
-                batch_size=fetch_size if batch_size is None else batch_size,
-                connection_string=conn_string,
-                # Pass through additional connection options
-                # that the user specified in the parent function
-                **kwargs,
+        if partition_list is not None and len(partition_list) > max_partitions:
+            # A concrete partition set may intentionally select a subset (e.g. by_value with an
+            # explicit value list), so it cannot be silently replaced by a single unpartitioned
+            # query -- raise rather than risk returning extra rows.
+            raise ValueError(
+                f"Partition count {len(partition_list)} exceeds max_partitions={max_partitions}; raise max_partitions or coarsen the partitions."
             )
 
-            # Track if we've yielded any batches yet
-            # This is necessary in case the query yields
-            # no records
-            count = 0
+        if partition_list is not None and len(partition_list) == 0:
+            yield _select_cols(pl.DataFrame({}, schema=schema), with_columns)
+            return
 
-            def select_cols(df) -> pl.DataFrame:
-                if with_columns is not None:
-                    with_cols_set = set(with_columns)
-                    return df.select(col for col in schema if col in with_cols_set)
-                return df
+        # Build (sql, client_predicate) per slice. For a partitioned read we AND the partition
+        # bound into the pushed predicate (reused by both the server-side SQL and the client-side
+        # safety filter) and retain the columns those predicates need through projection so the
+        # filter can be evaluated; n_rows is applied client-side across the stream.
+        if partition_list:
+            preds = [part.predicate for part in partition_list]
+            if predicate is not None:
+                preds.append(predicate)
+            effective_wc = retained_columns(preds, with_columns)
+            work: list[tuple[str, pl.Expr | None]] = []
+            for part in partition_list:
+                combined = part.predicate if predicate is None else (predicate & part.predicate)
+                work.append((_build_sql(combined, effective_wc, None, batch_size), combined))
+        else:
+            work = [(_build_sql(predicate, with_columns, n_rows, batch_size), predicate)]
 
-            for record_batch in batch_reader:
-                df = pl.DataFrame(record_batch)
-                if predicate is not None:
-                    df = df.filter(predicate)
-                yield select_cols(df)
-                count += 1
+        # Safety guard: only when we actually partition (>1 slice). Each slice wraps the query as a
+        # subquery and filters outside it, so a top-level LIMIT/OFFSET/TOP/FETCH/QUALIFY/window
+        # would return wrong rows -- raise. A top-level ORDER BY only loses global order (row set is
+        # still correct), so warn and proceed; the user can .sort() in Polars after the read.
+        if len(work) > 1:
+            unsafe = _partition_unsafe_clause(original_parsed_query)
+            if unsafe is not None:
+                raise ValueError(
+                    f"scan_db cannot partition a query containing {unsafe}: partitioning wraps the query in a "
+                    f"subquery and filters each slice, which changes the result. Apply it in Polars after the read "
+                    f"(e.g. .head()/.sort()), or read without `partitions=`."
+                )
+            if _has_top_level_order(original_parsed_query):
+                log.warning(
+                    "scan_db: the query's top-level ORDER BY is not applied across partitions -- each slice is read "
+                    "independently, so the rows are correct but not globally ordered. Use a Polars .sort() after the "
+                    "read, or read without `partitions=`."
+                )
 
-            if count == 0:
-                yield select_cols(pl.DataFrame({}, schema=schema))
+        for sql, _ in work:
+            log.debug("Executing SQL with pushdown: %s", sql)
+        log.debug("scan_db running %d partition(s)", len(work))
+
+        yielded_rows = 0
+
+        def _emit(df: pl.DataFrame):
+            """Yield a frame honouring the global n_rows cap across the stream."""
+            nonlocal yielded_rows
+            if n_rows is not None:
+                remaining = n_rows - yielded_rows
+                if remaining <= 0:
+                    return
+                if df.height > remaining:
+                    df = df.head(remaining)
+            yielded_rows += df.height
+            yield df
+
+        try:
+            if len(work) == 1:
+                # Single-connection streaming path (preserves original behaviour incl. empty result).
+                sql, client_predicate = work[0]
+                count = 0
+                for record_batch in _read(sql, batch_size):
+                    yield from _emit(_process_batch(record_batch, client_predicate, with_columns))
+                    count += 1
+                    if n_rows is not None and yielded_rows >= n_rows:
+                        break
+                if count == 0:
+                    yield _select_cols(pl.DataFrame({}, schema=schema), with_columns)
+                return
+
+            # Partitioned path: bounded-concurrency *streaming* fan-out. Each worker streams its
+            # slice's batches into a bounded queue (never a whole-slice list), so peak memory is a
+            # small constant x k x batch_size, independent of row count. `k` and the pool size come
+            # from one authoritative budget.
+            executor, budget = _get_sql_executor()
+            k = budget if max_concurrency is None else max(1, min(max_concurrency, budget))
+            stop = threading.Event()
+
+            def _put(q: queue.Queue, item) -> bool:
+                # Blocking put with periodic `stop` re-checks, so a worker parked on a full queue
+                # wakes and exits during cleanup instead of leaking. Only affects cleanup latency.
+                while not stop.is_set():
+                    try:
+                        q.put(item, timeout=_QUEUE_POLL_SECONDS)
+                        return True
+                    except queue.Full:
+                        continue
+                return False
+
+            # All workers stream into one shared bounded queue; yield whatever arrives, keeping `k`
+            # slices running. Output is in completion order (not deterministic) -- callers that need
+            # a specific order .sort() in Polars after the read.
+            shared: queue.Queue = queue.Queue(maxsize=k)
+            futures: dict[int, concurrent.futures.Future] = {}
+            next_submit = 0
+
+            def _launch():
+                nonlocal next_submit
+                idx = next_submit
+                sql, client_predicate = work[idx]
+                futures[idx] = executor.submit(_stream_slice, idx, sql, client_predicate, batch_size, with_columns, lambda it: _put(shared, it), stop)
+                next_submit += 1
+
+            try:
+                for _ in range(min(k, len(work))):
+                    _launch()
+                while futures:
+                    try:
+                        item = shared.get(timeout=_QUEUE_POLL_SECONDS)
+                    except queue.Empty:
+                        # Surface a worker that errored (its future carries the exception); leave
+                        # clean futures alone -- their `_SliceDone` marker (still queued) is the
+                        # sole authority for reconciling and relaunching, so we can't drop one.
+                        for fut in list(futures.values()):
+                            if fut.done() and fut.exception() is not None:
+                                fut.result()
+                        continue
+                    if isinstance(item, _SliceDone):
+                        futures.pop(item.idx).result()  # reconcile
+                        if next_submit < len(work):
+                            _launch()
+                        continue
+                    yield from _emit(item)
+                    if n_rows is not None and yielded_rows >= n_rows:
+                        return
+            finally:
+                stop.set()
+                for fut in futures.values():
+                    fut.cancel()
+                # cancel() cannot stop a worker that has already started, so wait for the running
+                # ones to observe `stop` and exit (bounded to one batch fetch) before unwinding.
+                # Otherwise we could return -- on n_rows early-stop or a sibling's error -- while a
+                # worker still holds a connection and fetches, leaking work onto the shared executor
+                # (and racing any DB state the caller tears down). wait() never re-raises, so a
+                # cleanup-time worker failure cannot mask the primary early-stop result or error.
+                concurrent.futures.wait(futures.values())
+
+            if yielded_rows == 0:
+                yield _select_cols(pl.DataFrame({}, schema=schema), with_columns)
 
         except Exception as e:
-            err_msg = f"Failed to execute SQL query: {final_sql}\nPredicate:\n{predicate}\n The `with_columns` used: {with_columns}\n"
+            err_msg = f"Failed to execute SQL query.\nPredicate:\n{predicate}\n The `with_columns` used: {with_columns}\n"
             err_msg += f"\n\nWhile running the above, received error: {e.__class__.__name__}:{e}"
             raise RuntimeError(err_msg) from e
 

--- a/polars_io_tools/tests/io_sources/test_lazy_sql_reader.py
+++ b/polars_io_tools/tests/io_sources/test_lazy_sql_reader.py
@@ -1,7 +1,9 @@
+import concurrent.futures
 import io
 import logging
 import sys
-from datetime import date
+import threading
+from datetime import date, datetime
 from types import SimpleNamespace
 
 import duckdb
@@ -2990,3 +2992,458 @@ def test_cast_map_rejects_unsupported_dtype(duckdb_connection):
     # emitting VARCHAR would misrepresent the data, so it must be rejected.
     with pytest.raises(ValueError, match="No SQL type mapping"):
         cpl.scan_db("SELECT * FROM RecordTbl", "fake_connection_string", cast_map={"RecordDate": pl.Boolean})
+
+
+class TestIntervalStr:
+    """Unit tests for the ``partitions`` interval-string normaliser."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("1mo", "1mo"),
+            ("2w", "2w"),
+            ("5d", "5d"),
+            ("1q", "1q"),
+            ("3y", "3y"),
+            ("mo", "1mo"),
+            ("month", "1mo"),
+            ("quarter", "1q"),
+            (7, "7d"),
+        ],
+    )
+    def test_valid(self, value, expected):
+        from polars_io_tools.io_sources.partitions import _interval_str
+
+        assert _interval_str(value) == expected
+
+    @pytest.mark.parametrize("value", ["", "1", "3h", "-2d", 0, -5, "1mth", True])
+    def test_invalid(self, value):
+        from polars_io_tools.io_sources.partitions import _interval_str
+
+        with pytest.raises((ValueError, TypeError)):
+            _interval_str(value)
+
+
+# scan_db fans partitions across a thread pool; DuckDB rejects concurrent use of a single
+# connection, so these tests install a lock-serialized reader over the shared connection.
+def _install_threadsafe_reader(monkeypatch):
+    lock = threading.Lock()
+
+    def _read(query, batch_size, connection_string, **kwargs):
+        with lock:
+            table = _duckdb_conn.execute(query).fetch_arrow_table()
+        return FakeBatchReader(table, batch_size)
+
+    monkeypatch.setitem(sys.modules, "arrow_odbc", SimpleNamespace(read_arrow_batches_from_odbc=_read))
+
+
+class TestScanDbPartitions:
+    """Tests for the opt-in ``partitions=`` reading path in ``scan_db``."""
+
+    QUERY = "SELECT * FROM CC_Bond"
+    # CC_Bond.EventDate spans many years; this window straddles several so buckets are non-trivial.
+    DATE_FILTER = (pl.col("EventDate") >= datetime(2013, 1, 1)) & (pl.col("EventDate") < datetime(2017, 1, 1))
+    COUNTRY_FILTER = pl.col("ISOCountryCode").is_in(["GT", "BD", "RO"])
+
+    @pytest.fixture(autouse=True)
+    def _threadsafe(self, monkeypatch):
+        _install_threadsafe_reader(monkeypatch)
+
+    def _sorted(self, df):
+        return df.sort(by=df.columns)
+
+    @pytest.mark.parametrize("every", ["1y", "1mo", "6mo", 90, "1q"])
+    def test_by_time_matches_unpartitioned(self, every):
+        baseline = cpl.scan_db(self.QUERY, "conn").filter(self.DATE_FILTER).collect()
+        got = cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_time("EventDate", every)).filter(self.DATE_FILTER).collect()
+        assert got.height > 0
+        assert_frame_equal(self._sorted(got), self._sorted(baseline))
+
+    def test_by_time_partition_count(self, caplog):
+        # [2013-01-01, 2017-01-01) split yearly is exactly four windows (exclusive upper bound).
+        with caplog.at_level(logging.DEBUG):
+            cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_time("EventDate", "1y")).filter(self.DATE_FILTER).collect()
+        assert any("running 4 partition(s)" in record.message for record in caplog.records)
+
+    def test_by_value_derived_from_predicate(self):
+        baseline = cpl.scan_db(self.QUERY, "conn").filter(self.COUNTRY_FILTER).collect()
+        got = cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_value("ISOCountryCode")).filter(self.COUNTRY_FILTER).collect()
+        assert got.height > 0
+        assert_frame_equal(self._sorted(got), self._sorted(baseline))
+
+    def test_by_value_explicit_groups(self):
+        values = [["GT", "BD"], "RO"]
+        flt = pl.col("ISOCountryCode").is_in(["GT", "BD", "RO"])
+        baseline = cpl.scan_db(self.QUERY, "conn").filter(flt).collect()
+        got = cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_value("ISOCountryCode", values)).filter(flt).collect()
+        assert_frame_equal(self._sorted(got), self._sorted(baseline))
+
+    def test_by_range_numeric(self):
+        flt = (pl.col("EventYear") >= 2013) & (pl.col("EventYear") < 2055)
+        baseline = cpl.scan_db(self.QUERY, "conn").filter(flt).collect()
+        got = cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_range("EventYear", every=10)).filter(flt).collect()
+        assert got.height > 0
+        assert_frame_equal(self._sorted(got), self._sorted(baseline))
+
+    def test_explicit_read_partition_list(self):
+        # All CC_Bond rows are FileType 'G', so this single explicit slice returns everything.
+        baseline = cpl.scan_db(self.QUERY, "conn").collect()
+        got = cpl.scan_db(self.QUERY, "conn", partitions=[cpl.ReadPartition(pl.col("FileType") == "G", key="G")]).collect()
+        assert_frame_equal(self._sorted(got), self._sorted(baseline))
+
+    def test_generator_partitions_retain_columns_under_projection(self):
+        # A one-shot generator of slices, plus a projection that omits the partition column: the
+        # column must still be retained to evaluate (and drop) the client-side filter.
+        flt = pl.col("ISOCountryCode").is_in(["GT", "BD", "RO"])
+        baseline = cpl.scan_db(self.QUERY, "conn").filter(flt).select("CentreCode").collect()
+        parts = (cpl.ReadPartition(pl.col("ISOCountryCode") == c, key=c) for c in ["GT", "BD", "RO"])
+        got = cpl.scan_db(self.QUERY, "conn", partitions=parts).filter(flt).select("CentreCode").collect()
+        assert got.height > 0
+        assert got.columns == ["CentreCode"]
+        assert_frame_equal(self._sorted(got), self._sorted(baseline))
+
+    def test_generator_partitions_are_reusable(self):
+        # A generator is materialised once, so re-collecting the same LazyFrame is not empty.
+        flt = pl.col("ISOCountryCode").is_in(["GT", "BD", "RO"])
+        parts = (cpl.ReadPartition(pl.col("ISOCountryCode") == c, key=c) for c in ["GT", "BD", "RO"])
+        lf = cpl.scan_db(self.QUERY, "conn", partitions=parts).filter(flt)
+        first, second = lf.collect(), lf.collect()
+        assert first.height > 0
+        assert_frame_equal(self._sorted(first), self._sorted(second))
+
+    def test_unbounded_predicate_falls_back_to_single_query(self, caplog):
+        with caplog.at_level(logging.DEBUG):
+            got = cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_time("EventDate")).collect()
+        baseline = cpl.scan_db(self.QUERY, "conn").collect()
+        assert_frame_equal(self._sorted(got), self._sorted(baseline))
+        assert any("running 1 partition(s)" in record.message for record in caplog.records)
+
+    def test_max_partitions_guardrail_raises(self):
+        with pytest.raises(pl.exceptions.ComputeError, match="exceeds max_partitions"):
+            cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_time("EventDate", "1d"), max_partitions=5).filter(self.DATE_FILTER).collect()
+
+    def test_projection_and_row_limit(self):
+        got = (
+            cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_time("EventDate", "1y"))
+            .filter(self.DATE_FILTER)
+            .select("CenterID", "EventDate")
+            .head(3)
+            .collect()
+        )
+        assert got.columns == ["CenterID", "EventDate"]
+        assert got.height == 3
+
+    def test_max_concurrency_matches_unpartitioned(self):
+        baseline = cpl.scan_db(self.QUERY, "conn").filter(self.DATE_FILTER).collect()
+        got = cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_time("EventDate", "1mo"), max_concurrency=1).filter(self.DATE_FILTER).collect()
+        assert_frame_equal(self._sorted(got), self._sorted(baseline))
+
+    def test_unknown_partition_column_raises(self):
+        with pytest.raises(ValueError, match="not_a_column"):
+            cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_time("not_a_column"))
+
+    def test_untranslatable_predicate_filters_client_side(self):
+        # A predicate that cannot be pushed to SQL is still enforced client-side, so the slice
+        # stays exact (here: only rows whose EventName contains "Day").
+        udf = pl.col("EventName").map_elements(lambda s: "Day" in s, return_dtype=pl.Boolean)
+        expected = cpl.scan_db(self.QUERY, "conn").filter(udf).collect()
+        got = cpl.scan_db(self.QUERY, "conn", partitions=[cpl.ReadPartition(udf, key=0)]).collect()
+        assert got.height > 0
+        assert_frame_equal(self._sorted(got), self._sorted(expected))
+
+    def test_explicit_partitions_over_max_raises(self):
+        parts = [cpl.ReadPartition(pl.col("ISOCountryCode") == c, key=c) for c in ["GT", "BD", "RO"]]
+        with pytest.raises(pl.exceptions.ComputeError, match="exceeds max_partitions"):
+            cpl.scan_db(self.QUERY, "conn", partitions=parts, max_partitions=2).collect()
+
+    def test_unordered_matches_unpartitioned(self):
+        # Completion order returns the same rows as an unpartitioned read (order aside).
+        baseline = cpl.scan_db(self.QUERY, "conn").filter(self.DATE_FILTER).collect()
+        got = cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_time("EventDate", "1mo")).filter(self.DATE_FILTER).collect()
+        assert got.height > 0
+        assert_frame_equal(self._sorted(got), self._sorted(baseline))
+
+    def test_unordered_row_limit(self):
+        # No outer predicate, so Polars pushes n_rows to the source and the partitioned fan-out
+        # itself must honour the limit (exercising _emit truncation and the early return).
+        groups = [["GT"], ["BD"], ["RO"]]
+        got = cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_value("ISOCountryCode", groups)).head(3).collect()
+        assert got.height == 3
+        assert set(got["ISOCountryCode"].to_list()) <= {"GT", "BD", "RO"}
+
+    def test_partitioned_query_with_order_by_warns_not_raises(self, caplog):
+        # A top-level ORDER BY only loses global order under partitioning (row set stays correct):
+        # warn and proceed, don't raise.
+        q = "SELECT * FROM CC_Bond ORDER BY EventDate DESC"
+        with caplog.at_level(logging.WARNING):
+            got = cpl.scan_db(q, "conn", partitions=cpl.by_time("EventDate", "1y")).filter(self.DATE_FILTER).collect()
+        baseline = cpl.scan_db(self.QUERY, "conn").filter(self.DATE_FILTER).collect()
+        assert_frame_equal(self._sorted(got), self._sorted(baseline))  # same rows
+        assert any("ORDER BY" in r.message for r in caplog.records)
+
+    @pytest.mark.parametrize(
+        ("query", "match"),
+        [
+            ("SELECT * FROM CC_Bond ORDER BY EventDate LIMIT 10", "LIMIT"),
+            ("SELECT * FROM CC_Bond OFFSET 5 ROWS", "OFFSET"),
+            ("SELECT *, ROW_NUMBER() OVER (ORDER BY EventDate) AS rn FROM CC_Bond", "window"),
+        ],
+    )
+    def test_partitioned_query_with_unsafe_clause_raises(self, query, match):
+        with pytest.raises((ValueError, pl.exceptions.ComputeError), match=match):
+            cpl.scan_db(query, "conn", partitions=cpl.by_time("EventDate", "1y")).filter(self.DATE_FILTER).collect()
+
+    def test_unpartitioned_query_with_limit_is_allowed(self):
+        # The guard only applies to a real (>1 slice) partitioned read; an unpartitioned query keeps
+        # its LIMIT.
+        got = cpl.scan_db("SELECT * FROM CC_Bond LIMIT 5", "conn").collect()
+        assert got.height == 5
+
+    def test_partitioned_head_does_not_push_limit_into_slices(self, monkeypatch):
+        # Per-slice LIMIT is unsafe when a slice predicate is enforced client-side, so it must never
+        # be pushed into a slice query; the client-side row counter trims instead.
+        captured: list[str] = []
+        lock = threading.Lock()
+
+        def _read(query, batch_size, connection_string, **kwargs):
+            with lock:
+                captured.append(query)
+                table = _duckdb_conn.execute(query).fetch_arrow_table()
+            return FakeBatchReader(table, batch_size)
+
+        monkeypatch.setitem(sys.modules, "arrow_odbc", SimpleNamespace(read_arrow_batches_from_odbc=_read))
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+        monkeypatch.setattr(cpl.io_sources.lazy_sql_reader, "_get_sql_executor", lambda: (pool, 3))
+        try:
+            got = cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_value("ISOCountryCode", [["GT"], ["BD"], ["RO"]])).head(2).collect()
+        finally:
+            pool.shutdown(wait=True)
+        assert got.height == 2
+        slice_sql = [q for q in captured if "IN (" in q]
+        assert slice_sql, "no slice SQL captured"
+        assert not any("LIMIT" in q.upper() or " TOP " in q.upper() for q in slice_sql)
+
+    def test_partition_worker_error_surfaces_with_slice_sql(self, monkeypatch):
+        lock = threading.Lock()
+
+        def _read(query, batch_size, connection_string, **kwargs):
+            if "'GT'" in query:
+                raise RuntimeError("odbc boom")
+            with lock:
+                table = _duckdb_conn.execute(query).fetch_arrow_table()
+            return FakeBatchReader(table, batch_size)
+
+        monkeypatch.setitem(sys.modules, "arrow_odbc", SimpleNamespace(read_arrow_batches_from_odbc=_read))
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+        monkeypatch.setattr(cpl.io_sources.lazy_sql_reader, "_get_sql_executor", lambda: (pool, 3))
+        try:
+            with pytest.raises((RuntimeError, pl.exceptions.ComputeError), match="partition slice"):
+                cpl.scan_db(self.QUERY, "conn", partitions=cpl.by_value("ISOCountryCode", [["GT"], ["BD"], ["RO"]])).collect()
+        finally:
+            pool.shutdown(wait=True)
+
+    def test_streaming_is_bounded_not_whole_slice(self, monkeypatch):
+        # Prove the workers STREAM: a bounded head(1) reads only a few batches, whereas whole-slice
+        # buffering would pull (nearly) every batch of every in-flight slice before yielding.
+        produced = [0]
+        lock = threading.Lock()
+
+        class _CountingReader:
+            def __init__(self, table):
+                self.schema = table.schema
+                self._it = iter(table.to_batches(max_chunksize=1))  # one row per batch, deterministically
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                batch = next(self._it)  # raises StopIteration at the end
+                with lock:
+                    produced[0] += 1
+                return batch
+
+        def _read(query, batch_size, connection_string, **kwargs):
+            with lock:
+                table = _duckdb_conn.execute(query).fetch_arrow_table()
+            # Replicate rows so a slice has *many* one-row batches: this makes "streaming a few
+            # batches" vs "reading the whole slice" a large, unambiguous difference on a tiny fixture.
+            if table.num_rows:
+                table = pa.concat_tables([table] * 50)
+            return _CountingReader(table)
+
+        monkeypatch.setitem(sys.modules, "arrow_odbc", SimpleNamespace(read_arrow_batches_from_odbc=_read))
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+        monkeypatch.setattr(cpl.io_sources.lazy_sql_reader, "_get_sql_executor", lambda: (pool, 3))
+
+        # Enumerated slices need no pushed predicate, so `.head(1)` (no intervening filter) pushes
+        # n_rows into the source and exercises early-stop; a filter would block that pushdown.
+        parts = cpl.by_value("EventYear", [[2013], [2021], [2053], [2054]])
+        lf = cpl.scan_db(self.QUERY, "conn", partitions=parts)
+        try:
+            full = lf.collect()
+            with lock:
+                full_batches = produced[0]
+            assert full.height > 9 and full_batches > 20  # a full read pulls many batches
+
+            with lock:
+                produced[0] = 0
+            got = lf.head(1).collect()
+            assert got.height == 1
+            with lock:
+                head_batches = produced[0]
+            # The shared queue holds at most k items and each of the k workers parks after its next
+            # blocked put, so head(1) reads only a handful of batches -- far fewer than a whole slice.
+            assert head_batches <= 3 * 3, f"head(1) read {head_batches} batches (streaming should read only a few)"
+            assert head_batches < full_batches
+        finally:
+            pool.shutdown(wait=True)
+
+    def test_early_stop_joins_running_workers(self, monkeypatch):
+        # On n_rows early-stop the generator must not return while slice workers are still fetching:
+        # Future.cancel() cannot stop an already-running worker, so cleanup joins them. Each slice
+        # streams through a generator that records entry and (via finally) exit; when head(1) returns,
+        # every worker that started must also have exited -- else a connection/query is still live.
+        # Without the join a mid-stream worker leaves entered > exited.
+        import time
+
+        entered = [0]
+        exited = [0]
+        lock = threading.Lock()
+
+        class _SlowReader:
+            # Has `.schema` (read by the schema probe, which never iterates) and streams one-row
+            # batches with a per-batch sleep so workers stay mid-stream. __iter__ is a generator:
+            # when _stream_slice abandons it on stop, it is deallocated and its finally runs.
+            def __init__(self, table):
+                self.schema = table.schema
+                self._table = table
+
+            def __iter__(self):
+                with lock:
+                    entered[0] += 1
+                try:
+                    for batch in self._table.to_batches(max_chunksize=1):
+                        time.sleep(0.02)  # hold every worker inside its stream when the limit hits
+                        yield batch
+                finally:
+                    with lock:
+                        exited[0] += 1
+
+        def _read(query, batch_size, connection_string, **kwargs):
+            with lock:
+                table = _duckdb_conn.execute(query).fetch_arrow_table()
+            if table.num_rows:
+                table = pa.concat_tables([table] * 50)  # many one-row batches, so workers stay mid-stream
+            return _SlowReader(table)
+
+        monkeypatch.setitem(sys.modules, "arrow_odbc", SimpleNamespace(read_arrow_batches_from_odbc=_read))
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+        monkeypatch.setattr(cpl.io_sources.lazy_sql_reader, "_get_sql_executor", lambda: (pool, 3))
+
+        parts = cpl.by_value("EventYear", [[2013], [2021], [2053]])  # k == number of slices == 3
+        try:
+            got = cpl.scan_db(self.QUERY, "conn", partitions=parts).head(1).collect()
+            assert got.height == 1
+            with lock:
+                assert entered[0] >= 1, "expected at least one worker to start streaming"
+                assert entered[0] == exited[0], f"{entered[0] - exited[0]} worker(s) still running after collect() returned"
+        finally:
+            pool.shutdown(wait=True)
+
+
+def test_connection_budget_env_parse(monkeypatch):
+    import polars_io_tools.io_sources.lazy_sql_reader as lsr
+
+    # Blank/whitespace is treated as unset (default) -- never crashes import or first use.
+    for blank in ("", " ", "  "):
+        monkeypatch.setenv("POLARS_IO_TOOLS_MAX_SQL_CONNECTIONS", blank)
+        assert lsr._resolve_sql_connection_budget() == min(pl.thread_pool_size(), 8)
+    # Malformed values raise a clear error naming the variable, at use -- not at import.
+    for bad in ("auto", "8.5", "0", "-1"):
+        monkeypatch.setenv("POLARS_IO_TOOLS_MAX_SQL_CONNECTIONS", bad)
+        with pytest.raises(ValueError, match="POLARS_IO_TOOLS_MAX_SQL_CONNECTIONS"):
+            lsr._resolve_sql_connection_budget()
+    monkeypatch.setenv("POLARS_IO_TOOLS_MAX_SQL_CONNECTIONS", " 4 ")
+    assert lsr._resolve_sql_connection_budget() == 4
+
+
+def test_partition_worker_error_surfaces(monkeypatch):
+    # Exercise the completion-order failure-reconciliation path (shared queue): an errored worker
+    # that posts no done marker must still surface, carrying its slice SQL.
+    lock = threading.Lock()
+
+    def _read(query, batch_size, connection_string, **kwargs):
+        if "'RO'" in query:
+            raise RuntimeError("odbc kaboom")
+        with lock:
+            table = _duckdb_conn.execute(query).fetch_arrow_table()
+        return FakeBatchReader(table, batch_size)
+
+    monkeypatch.setitem(sys.modules, "arrow_odbc", SimpleNamespace(read_arrow_batches_from_odbc=_read))
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+    monkeypatch.setattr(cpl.io_sources.lazy_sql_reader, "_get_sql_executor", lambda: (pool, 3))
+    try:
+        with pytest.raises((RuntimeError, pl.exceptions.ComputeError), match="'RO'"):
+            cpl.scan_db("SELECT * FROM CC_Bond", "conn", partitions=cpl.by_value("ISOCountryCode", [["GT"], ["BD"], ["RO"]])).collect()
+    finally:
+        pool.shutdown(wait=True)
+
+
+def test_partial_submission_failure_does_not_leak_workers(monkeypatch):
+    # If task submission fails partway through the initial fan-out, the workers that DID start must
+    # still be signalled to stop (the failing submit happens inside the cleanup try/finally).
+    lock = threading.Lock()
+
+    def _read(query, batch_size, connection_string, **kwargs):
+        with lock:
+            table = _duckdb_conn.execute(query).fetch_arrow_table()
+        return FakeBatchReader(table, batch_size)
+
+    monkeypatch.setitem(sys.modules, "arrow_odbc", SimpleNamespace(read_arrow_batches_from_odbc=_read))
+    real_pool = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+
+    class _FlakyExecutor:
+        def __init__(self):
+            self.n = 0
+
+        def submit(self, *args, **kwargs):
+            self.n += 1
+            if self.n == 2:  # accept the first worker, blow up on the second submission
+                raise RuntimeError("submit boom")
+            return real_pool.submit(*args, **kwargs)
+
+    monkeypatch.setattr(cpl.io_sources.lazy_sql_reader, "_get_sql_executor", lambda: (_FlakyExecutor(), 3))
+    try:
+        with pytest.raises((RuntimeError, pl.exceptions.ComputeError), match="submit boom"):
+            cpl.scan_db("SELECT * FROM CC_Bond", "conn", partitions=cpl.by_value("ISOCountryCode", [["GT"], ["BD"], ["RO"]])).collect()
+        # The one accepted worker must have exited (stop was set); the pool drains cleanly.
+        real_pool.shutdown(wait=True)  # would hang if a worker were stranded on a full queue
+    finally:
+        real_pool.shutdown(wait=True)
+
+
+@pytest.mark.parametrize("dialect_query", ["duckdb", "tsql"])
+@pytest.mark.parametrize(
+    ("query", "unsafe", "order"),
+    [
+        ("SELECT * FROM t", None, False),
+        ("SELECT * FROM t ORDER BY id", None, True),
+        ("SELECT * FROM t LIMIT 5", "LIMIT/TOP", False),
+        ("SELECT * FROM (SELECT * FROM t LIMIT 5) s", None, False),  # nested LIMIT is the user's own semantics
+        ("SELECT TOP 10 * FROM t", "LIMIT/TOP", False),
+        ("SELECT * FROM a UNION ALL SELECT * FROM b ORDER BY 1", None, True),
+        ("SELECT * FROM a UNION ALL SELECT * FROM b LIMIT 10", "LIMIT/TOP", False),
+        ("SELECT x FROM t QUALIFY ROW_NUMBER() OVER (PARTITION BY g ORDER BY id) = 1", "a window function", False),
+    ],
+)
+def test_partition_guard_ast_detection(dialect_query, query, unsafe, order):
+    from sqlglot import parse_one
+
+    from polars_io_tools.io_sources.lazy_sql_reader import _has_top_level_order, _partition_unsafe_clause
+
+    # TOP is MSSQL-only syntax.
+    if "TOP" in query and dialect_query != "tsql":
+        return
+    parsed = parse_one(query, dialect=dialect_query)
+    assert _partition_unsafe_clause(parsed) == unsafe
+    assert _has_top_level_order(parsed) == order


### PR DESCRIPTION
## Description

Adds a `partitions=` argument to `scan_db` that splits a read into independent slices pulled over parallel connections and **streamed batch-by-batch**, speeding up large scan-like extracts whose single-cursor transfer is the bottleneck. Peak memory stays proportional to the connection budget × the Arrow batch size — a slice is never fully buffered — regardless of total row count.

`scan_db` consumes the shared read-partition vocabulary from `io_sources.partitions` — the same `ReadPartition` / `by_time` / `by_value` / `by_range` used by the distributed executor:

- `by_time(column, every)` — calendar windows from the pushed-down date range (`"1mo"`/`"2w"`/`"5d"`/`"1q"`/`"1y"` or an int of days)
- `by_value(column, values=None)` — one slice per discrete value (derived from an `IN` filter when omitted)
- `by_range(column, every)` — fixed-width numeric buckets
- an explicit iterable of `ReadPartition(predicate, key)`

## How it works

Each slice's bound is ANDed into the pushed-down predicate and routed through the existing `apply_polars_io_source_exprs` (so MSSQL `ORDER BY`/`OPTION` hoisting and identifier quoting are reused). Columns the predicates need are retained through projection pushdown and the combined predicate is re-applied client-side, so slices stay exact even if only part of the predicate translates to SQL. Workers stream into a shared bounded queue and are relaunched as slices complete, keeping at most `k` connections live; `n_rows`/`head` pushdown stops the fan-out early and joins any in-flight workers before returning. A partitioner that cannot derive a bounded split falls back to a single query; a known-empty split yields an empty frame; an over-limit split raises.

Concurrency is governed by a shared connection budget (`POLARS_IO_TOOLS_MAX_SQL_CONNECTIONS`, default `min(pl.thread_pool_size(), 8)` — self-throttling to 1 in fan-out clusters that pin `POLARS_MAX_THREADS=1`), with an optional `max_concurrency=` to throttle below it.

## Ordering / sorted output

Rows are yielded in **completion order** (whichever slice's batches arrive first), which is not deterministic — apply a Polars `.sort()` after the read if you need a specific order (this matches connector-x, which likewise has no ordering knob). A top-level `ORDER BY` is honoured only for an **unpartitioned** read; under partitioning it can't be re-established across independent slices, so it's dropped with a warning (the row set is still correct). Clauses that would change the *result set* under partitioning — a top-level `LIMIT`/`OFFSET`/`TOP`/`FETCH`, `QUALIFY`, or a window function — raise instead; apply them in Polars after the read.

## Tests / docs

Unit tests for the builders and the partitioned reader (DuckDB-backed), including bounded-memory / head-pushdown and early-stop worker-join coverage, plus a how-to section in the Reading and Writing Data wiki. `make lint-py` / `lint-docs` clean.
