### PR TITLE
Re-add multi_source as a silent backwards-compat alias of pushdown_combine

### DIFF
--- a/polars_io_tools/io_sources/__init__.py
+++ b/polars_io_tools/io_sources/__init__.py
@@ -20,6 +20,7 @@ from .lazy_iter_rows import *
 from .lazy_narwhals_reader import *
 from .lazy_probe import probe, probe as _lazy_probe
 from .lazy_sql_reader import *
+from .multi_source import *  # backwards-compat alias of pushdown_combine
 from .pushdown_combine import *
 from .pushdown_pivot import *
 from .pushdown_unpivot import *
@@ -39,6 +40,7 @@ if TYPE_CHECKING:
     from .lazy_clickhouse_writer import sink_clickhouse  # noqa: TC004
     from .lazy_data_generator import scan_synthetic_panel, scan_synthetic_regression
     from .lazy_iter_rows import iter_rows  # noqa: TC004
+    from .multi_source import multi_source
     from .pushdown_combine import FilterSpec, pushdown_combine
     from .pushdown_pivot import pushdown_pivot
     from .pushdown_unpivot import pushdown_unpivot

--- a/polars_io_tools/io_sources/multi_source.py
+++ b/polars_io_tools/io_sources/multi_source.py
@@ -1,0 +1,18 @@
+"""Backwards-compatibility alias for the former ``multi_source`` entry point.
+
+``multi_source`` was renamed to :func:`pushdown_combine` in v0.2.0. This module
+re-exports the current implementation under the historical name so that imports
+from the pre-0.2.0 surface keep working::
+
+    from polars_io_tools import multi_source
+    from polars_io_tools.io_sources import multi_source
+    from polars_io_tools.io_sources.multi_source import FilterSpec, multi_source
+
+``multi_source`` is the same object as :func:`pushdown_combine`.
+"""
+
+from .pushdown_combine import FilterSpec, pushdown_combine
+
+multi_source = pushdown_combine
+
+__all__ = ("FilterSpec", "multi_source")

--- a/polars_io_tools/tests/io_sources/test_multi_source_compat.py
+++ b/polars_io_tools/tests/io_sources/test_multi_source_compat.py
@@ -1,0 +1,35 @@
+"""Backwards-compat: ``multi_source`` must alias ``pushdown_combine``.
+
+``multi_source`` was public in v0.1.0–v0.1.2 and renamed to ``pushdown_combine``
+in v0.2.0. The ``multi_source`` name is kept as a silent alias so the historical
+import paths keep resolving.
+"""
+
+import importlib
+
+import polars_io_tools as piot
+
+
+def test_multi_source_is_pushdown_combine():
+    assert piot.multi_source is piot.pushdown_combine
+
+
+def test_multi_source_import_paths_resolve():
+    from polars_io_tools import FilterSpec, multi_source
+    from polars_io_tools.io_sources import (
+        FilterSpec as FilterSpec_ios,
+        multi_source as multi_source_ios,
+    )
+    from polars_io_tools.io_sources.multi_source import (
+        FilterSpec as FilterSpec_mod,
+        multi_source as multi_source_mod,
+    )
+
+    assert multi_source is multi_source_ios is multi_source_mod is piot.pushdown_combine
+    assert FilterSpec is FilterSpec_ios is FilterSpec_mod is piot.FilterSpec
+
+
+def test_multi_source_module_importable():
+    mod = importlib.import_module("polars_io_tools.io_sources.multi_source")
+    assert mod.multi_source is piot.pushdown_combine
+    assert mod.__all__ == ("FilterSpec", "multi_source")


### PR DESCRIPTION
## Summary

`multi_source` was a public, released symbol in **v0.1.0–v0.1.2**. It was renamed to `pushdown_combine` in **v0.2.0** with no compatibility alias, so 0.1.x consumers break on upgrade.

This PR re-adds `multi_source` as a **silent** backwards-compat alias (no `DeprecationWarning`, by explicit maintainer decision), restoring the historical import paths:

- `polars_io_tools.multi_source`
- `polars_io_tools.io_sources.multi_source`
- `from polars_io_tools.io_sources.multi_source import multi_source, FilterSpec`

`multi_source` and `FilterSpec` are the **same objects** as their `pushdown_combine` counterparts.

## Changes

- **`io_sources/multi_source.py`** (new): re-exports `pushdown_combine` as `multi_source`, plus `FilterSpec`.
- **`io_sources/__init__.py`**: `from .multi_source import *` (alphabetical) + TYPE_CHECKING declaration.
- **`tests/io_sources/test_multi_source_compat.py`** (new): asserts alias identity and that all pre-0.2.0 import paths resolve.

## Target release

Intended for a **0.2.2 patch** release. Version bump left to the `bump-my-version` release step (`bump-my-version bump patch`); this PR contains no version changes.

## Testing

- New compat tests: 3 passed.
- Existing `test_pushdown_combine.py`: 92 passed.
- Ruff: clean.

## Review

Reviewed by Sol (GPT-5.6 Sol) — verdict **APPROVE**: all historical import paths resolve, object identity preserved, star-import shadowing matches v0.1.2 behavior, tests adequate.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>